### PR TITLE
Add Prometheus metrics

### DIFF
--- a/listeners/http_sysinfo.go
+++ b/listeners/http_sysinfo.go
@@ -7,9 +7,11 @@ package listeners
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"reflect"
+	"runtime"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -148,6 +150,11 @@ func (l *HTTPStats) metricsHandler(w http.ResponseWriter, req *http.Request) {
 // WriteMetrics writes the metrics in a prometheus format to the writer.
 func (l *HTTPStats) WriteMetrics(w io.Writer) error {
 	info := *l.sysInfo.Clone()
+
+	_, err := fmt.Fprintf(w, "mochi_co_mqtt_info{version=%q,goversion=%q} 1\n", info.Version, runtime.Version())
+	if err != nil {
+		return err
+	}
 
 	v := reflect.ValueOf(info)
 	for _, m := range l.metricsInt64 {

--- a/listeners/http_sysinfo.go
+++ b/listeners/http_sysinfo.go
@@ -46,7 +46,7 @@ func NewHTTPStats(id, address string, config *Config, sysInfo *system.Info) *HTT
 		config = new(Config)
 	}
 
-	v := reflect.TypeOf(*sysInfo)
+	v := reflect.TypeOf(sysInfo).Elem()
 	metricsInt64 := make([]metric, 0, v.NumField())
 	for i := 0; i < v.NumField(); i++ {
 		f := v.Field(i)

--- a/listeners/http_sysinfo_test.go
+++ b/listeners/http_sysinfo_test.go
@@ -5,9 +5,11 @@
 package listeners
 
 import (
+	"bytes"
 	"encoding/json"
 	"io"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -124,4 +126,22 @@ func TestHTTPStatsServeTLSAndClose(t *testing.T) {
 
 	time.Sleep(time.Millisecond)
 	l.Close(MockCloser)
+}
+
+func TestHTTPStatsMetrics(t *testing.T) {
+	sysInfo := &system.Info{
+		Version: "test",
+	}
+
+	// setup http stats listener
+	l := NewHTTPStats("t1", testAddr, nil, sysInfo)
+	err := l.Init(nil)
+	require.NoError(t, err)
+
+	buf := &bytes.Buffer{}
+	err = l.WriteMetrics(buf)
+	require.NoError(t, err)
+
+	s := buf.String()
+	require.True(t, strings.HasPrefix(s, `mochi_co_mqtt_info{version="test",goversion="go`), s)
 }


### PR DESCRIPTION
Since #184 has been abandoned, here is my take on adding Prometheus metrics.

It exposes something like:
```
mochi_co_mqtt_info{version="2.2.6",goversion="go1.20.2"} 1
started 1678799214
time 1678799670
uptime 456
bytes_received 0
bytes_sent 0
clients_connected 0
clients_disconnected 0
clients_maximum 0
clients_total 0
messages_received 0
messages_sent 0
messages_dropped 0
retained 0
inflight 0
inflight_dropped 0
subscriptions 0
packets_received 0
packets_sent 0
memory_alloc 2998272
threads 7
```

I made a couple of decisions, which could be challenged:
- don't add external dependencies (since the metrics format is quite simple, I don't think that this is needed)
- use reflection, so that any change to the `system.Info` struct is automatically exposed on `/metrics`
- export a `WriteMetrics` method (since I intend to push the metrics to VictoriaMetrics, instead of pulling)
