### PR TITLE
Fix readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,16 @@ import (
 )
 
 func main() {
+  
+  // Create signals channel to run server until interrupted
+  sigs := make(chan os.Signal, 1)
+	done := make(chan bool, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigs
+		done <- true
+	}()
+
   // Create the new MQTT Server.
   server := mqtt.New(nil)
   
@@ -107,10 +117,18 @@ func main() {
     log.Fatal(err)
   }
   
-  err = server.Serve()
-  if err != nil {
-    log.Fatal(err)
-  }
+
+  go func() {
+		err := server.Serve()
+		if err != nil {
+			log.Fatal(err)
+		}
+	}()
+
+  // Run server until interrupted
+  <-done
+
+  // Cleanup
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Importing Mochi MQTT as a package requires just a few lines of code to get start
 import (
   "log"
 
-  "github.com/mochi-mqtt/server/v2"
+  mqtt "github.com/mochi-mqtt/server/v2"
   "github.com/mochi-mqtt/server/v2/hooks/auth"
   "github.com/mochi-mqtt/server/v2/listeners"
 )

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ func main() {
   
 
   go func() {
-	err := server.Serve()
+    err := server.Serve()
     if err != nil {
       log.Fatal(err)
     }

--- a/README.md
+++ b/README.md
@@ -90,15 +90,14 @@ import (
 )
 
 func main() {
-  
   // Create signals channel to run server until interrupted
   sigs := make(chan os.Signal, 1)
-	done := make(chan bool, 1)
-	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
-	go func() {
-		<-sigs
-		done <- true
-	}()
+  done := make(chan bool, 1)
+  signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+  go func() {
+    <-sigs
+    done <- true
+  }()
 
   // Create the new MQTT Server.
   server := mqtt.New(nil)
@@ -115,11 +114,11 @@ func main() {
   
 
   go func() {
-		err := server.Serve()
-		if err != nil {
-			log.Fatal(err)
-		}
-	}()
+	err := server.Serve()
+    if err != nil {
+      log.Fatal(err)
+    }
+  }()
 
   // Run server until interrupted
   <-done


### PR DESCRIPTION
Update the example in the README to better reflect real world use of the server. This includes adding signals, creating a go routine for `server.Serve()` and blocking until interrupted.