### PR TITLE
Inline Client Subscriptions prototype

### DIFF
--- a/clients.go
+++ b/clients.go
@@ -107,12 +107,18 @@ type Client struct {
 
 // ClientConnection contains the connection transport and metadata for the client.
 type ClientConnection struct {
-	Conn     net.Conn          // the net.Conn used to establish the connection
-	bconn    *bufio.ReadWriter // a buffered net.Conn for reading packets
-	Remote   string            // the remote address of the client
-	Listener string            // listener id of the client
-	Inline   bool              // client is an inline programmetic client
+	Conn       net.Conn               // the net.Conn used to establish the connection
+	bconn      *bufio.ReadWriter      // a buffered net.Conn for reading packets
+	Remote     string                 // the remote address of the client
+	Listener   string                 // listener id of the client
+	Inline     bool                   // client is an inline programmatic client
+	InlineSubs map[string]InlineSubFn // a map of inline subs callback functions keyed on subscription id
 }
+
+// InlineSubFn is the signature for a callback function which will be called
+// when an inline client receives a message on a topic it is subscribed to.
+// The sub argument contains information about the subscription that was matched for any filters.
+type InlineSubFn func(cl *Client, sub packets.Subscription, pk packets.Packet)
 
 // ClientProperties contains the properties which define the client behaviour.
 type ClientProperties struct {

--- a/clients.go
+++ b/clients.go
@@ -99,7 +99,7 @@ func (cl *Clients) GetByListener(id string) []*Client {
 type Client struct {
 	Properties   ClientProperties // client properties
 	State        ClientState      // the operational state of the client.
-	Net          ClientConnection // network connection state of the clinet
+	Net          ClientConnection // network connection state of the client
 	ID           string           // the client id.
 	ops          *ops             // ops provides a reference to server ops.
 	sync.RWMutex                  // mutex
@@ -134,7 +134,7 @@ type Will struct {
 	Retain            bool                   // -
 }
 
-// State tracks the state of the client.
+// ClientState tracks the state of the client.
 type ClientState struct {
 	TopicAliases    TopicAliases         // a map of topic aliases
 	stopCause       atomic.Value         // reason for stopping

--- a/examples/direct/main.go
+++ b/examples/direct/main.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2022 mochi-mqtt, mochi-co
+// SPDX-FileContributor: mochi-co
+
+package main
+
+import (
+	"github.com/mochi-mqtt/server/v2/hooks/auth"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/mochi-mqtt/server/v2"
+	"github.com/mochi-mqtt/server/v2/packets"
+)
+
+func main() {
+	sigs := make(chan os.Signal, 1)
+	done := make(chan bool, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigs
+		done <- true
+	}()
+
+	var err error
+	server := mqtt.New(nil)
+	_ = server.AddHook(new(auth.AllowHook), nil)
+
+	// Start the server
+	go func() {
+		err := server.Serve()
+		if err != nil {
+			log.Fatal(err)
+		}
+	}()
+
+	// Use inline clients (inline=true) to inject and receive messages directly from the broker.
+	cl := server.NewClient(nil, "local", "inline", true)
+
+	// Demonstration of using an inline client to directly subscribe to a topic and receive a message when
+	// that subscription is activated. The inline subscription method uses the same internal subscription logic
+	// as used for external (normal) clients.
+	go func() {
+		// Inline subscriptions can also receive retained messages on subscription.
+		_ = server.Publish("direct/retained", []byte("retained message"), true, 0)
+		_ = server.Publish("direct/alternate/retained", []byte("some other retained message"), true, 0)
+
+		// Subscribe to a filter and handle any received messages via a callback function.
+		callbackFn := func(cl *mqtt.Client, sub packets.Subscription, pk packets.Packet) {
+			server.Log.Info().Str("topic", pk.TopicName).Str("payload", string(pk.Payload)).Msgf("inline client received message from subscription")
+		}
+		server.Log.Info().Msgf("inline client subscribing")
+		err = server.Subscribe(cl, "direct/#", 2, callbackFn)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}()
+
+	// There is a shorthand convenience function, Publish, for easily sending
+	// publish packets if you are not concerned with creating your own packets.
+	go func() {
+		for range time.Tick(time.Second * 3) {
+			err := server.Publish("direct/publish", []byte("scheduled message"), false, 0)
+			if err != nil {
+				server.Log.Error().Err(err).Msg("server.Publish")
+			}
+			server.Log.Info().Msgf("main.go issued direct message to direct/publish")
+		}
+	}()
+
+	go func() {
+		time.Sleep(time.Second * 10)
+		// Unsubscribe from the same filter to stop receiving messages.
+		server.Log.Info().Msgf("inline client unsubscribing")
+		err := server.Unsubscribe(cl, "direct/#")
+		if err != nil {
+			server.Log.Error().Err(err).Msg("server.Unsubscribe")
+		}
+	}()
+	// If you want to have more control over your packets, you can directly inject a packet of any kind into the broker.
+	//go func() {
+	//	for range time.Tick(time.Second * 5) {
+	//		err := server.InjectPacket(cl, packets.Packet{
+	//			FixedHeader: packets.FixedHeader{
+	//				Type: packets.Publish,
+	//			},
+	//			TopicName: "direct/publish",
+	//			Payload:   []byte("injected scheduled message"),
+	//		})
+	//		if err != nil {
+	//			log.Fatal(err)
+	//		}
+	//	}
+	//}()
+
+	<-done
+	server.Log.Warn().Msg("caught signal, stopping...")
+	_ = server.Close()
+	server.Log.Info().Msg("main.go finished")
+}

--- a/examples/hooks/main.go
+++ b/examples/hooks/main.go
@@ -48,28 +48,7 @@ func main() {
 		}
 	}()
 
-	// Demonstration of directly publishing messages to a topic via the
-	// `server.Publish` method. Subscribe to `direct/publish` using your
-	// MQTT client to see the messages.
-	go func() {
-		cl := server.NewClient(nil, "local", "inline", true)
-		for range time.Tick(time.Second * 1) {
-			err := server.InjectPacket(cl, packets.Packet{
-				FixedHeader: packets.FixedHeader{
-					Type: packets.Publish,
-				},
-				TopicName: "direct/publish",
-				Payload:   []byte("injected scheduled message"),
-			})
-			if err != nil {
-				server.Log.Error().Err(err).Msg("server.InjectPacket")
-			}
-			server.Log.Info().Msgf("main.go injected packet to direct/publish")
-		}
-	}()
-
-	// There is also a shorthand convenience function, Publish, for easily sending
-	// publish packets if you are not concerned with creating your own packets.
+	// Using the direct publish method to issue packets into the broker to trigger our example hook.
 	go func() {
 		for range time.Tick(time.Second * 5) {
 			err := server.Publish("direct/publish", []byte("packet scheduled message"), false, 0)

--- a/server.go
+++ b/server.go
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: 2022 mochi-mqtt, mochi-co
 // SPDX-FileContributor: mochi-co
 
-// package mqtt provides a high performance, fully compliant MQTT v5 broker server with v3.1.1 backward compatibility.
+// Package mqtt provides a high performance, fully compliant MQTT v5 broker server with v3.1.1 backward compatibility.
 package mqtt
 
 import (
@@ -26,8 +26,8 @@ import (
 )
 
 const (
-	Version                       = "2.3.0"  // the current server version.
-	defaultSysTopicInterval int64 = 1        // the interval between $SYS topic publishes
+	Version                       = "2.3.0" // the current server version.
+	defaultSysTopicInterval int64 = 1       // the interval between $SYS topic publishes
 )
 
 var (
@@ -418,7 +418,7 @@ func (s *Server) receivePacket(cl *Client, pk packets.Packet) error {
 		if code, ok := err.(packets.Code); ok &&
 			cl.Properties.ProtocolVersion == 5 &&
 			code.Code >= packets.ErrUnspecifiedError.Code {
-			s.DisconnectClient(cl, code)
+			_ = s.DisconnectClient(cl, code)
 		}
 
 		s.Log.Warn().Err(err).Str("client", cl.ID).Str("listener", cl.Net.Listener).Interface("pk", pk).Msg("error processing packet")
@@ -456,7 +456,7 @@ func (s *Server) validateConnect(cl *Client, pk packets.Packet) packets.Code {
 // session is abandoned.
 func (s *Server) inheritClientSession(pk packets.Packet, cl *Client) bool {
 	if existing, ok := s.Clients.Get(pk.Connect.ClientIdentifier); ok {
-		s.DisconnectClient(existing, packets.ErrSessionTakenOver)                                       // [MQTT-3.1.4-3]
+		_ = s.DisconnectClient(existing, packets.ErrSessionTakenOver)                                   // [MQTT-3.1.4-3]
 		if pk.Connect.Clean || (existing.Properties.Clean && existing.Properties.ProtocolVersion < 5) { // [MQTT-3.1.2-4] [MQTT-3.1.4-4]
 			s.UnsubscribeClient(existing)
 			existing.ClearInflights(math.MaxInt64, 0)
@@ -643,7 +643,7 @@ func (s *Server) processPingreq(cl *Client, _ packets.Packet) error {
 	})
 }
 
-// Publish publishes a publish packet into the broker as if it were sent from the speicfied client.
+// Publish publishes a publish packet into the broker as if it were sent from the specified client.
 // This is a convenience function which wraps InjectPacket. As such, this method can publish packets
 // to any topic (including $SYS) and bypass ACL checks. The qos byte is used for limiting the
 // outbound qos (mqtt v5) rather than issuing to the broker (we assume qos 2 complete).
@@ -1286,7 +1286,7 @@ func (s *Server) Close() error {
 func (s *Server) closeListenerClients(listener string) {
 	clients := s.Clients.GetByListener(listener)
 	for _, cl := range clients {
-		s.DisconnectClient(cl, packets.ErrServerShuttingDown)
+		_ = s.DisconnectClient(cl, packets.ErrServerShuttingDown)
 	}
 }
 


### PR DESCRIPTION
Following the discussion in #279 (_Direct subscribe for embedded use case_), I've put together a prototype implementation of inline subscriptions as a counterpart of the `server.Publish` method.

I thought about this for almost two weeks and implemented several different versions. There were three core solutions which met the requirements of the direct subscription feature:

- **Hook Model**: An implementation which used the existing hook system and added an additional hook beside `OnPublished`. The user could add new 'subscriptions' - topic filters and callback methods, and then the hook would be triggered when a message is published. Any subscriptions on this hook would be iterated, and a new internal topic comparison method (i.e. does topic name match filter) would be used to determine if the message should be provided to the given callback.  
  - Good: Fairly simple to implement. Purely observational approach - didn't meaningfully interact with any existing internal code.
  - Not so good: didn't meaningfully interact with any existing internal code, so most topic features were unusable (e.g. retained), not reflective of actual usage. Required implementation of an entirely new topic matching system, which is slow at scale.
- **Outbound channel**: We already implement an `outbound` channel which receives messages that will be sent to the client. I had some ideas around exposing this channel for developers to access.
  - Good: Using channels would have felt 'proper' and 'sophisticated'.
  - Not so good: All subscribed messages would come through on the same source. Still requires topic matching on the developer side. No clear way to make the subscriptions.
- **Inline Client changes**: We already use special 'inline' clients in order to publish messages directly (via `server.Publish` and `server.InjectPacket`. It seemed reasonable that we could also allow inline clients to have subscriptions too, which triggered callbacks instead of writing packets to the network.
   -  Good: Works almost exactly as if the client was external. Can receive retained messages. Simple to understand.
   - Not so good: Weird things might happen if you injected a totally custom subscription packet via `server.InjectPacket`. However, this customisability may also be a benefit to some. More Inline Client specific code.

Ultimately, the inline client approach was the only implementation which made both technical and intuitive sense. 

There are two new methods:

- `func (s *Server) Subscribe(cl *Client, filter string, id int, callback InlineSubFn) error`, and
- `func (s *Server) Unsubscribe(cl *Client, filter string) error`

`id` is an MQTTv5 subscription identifier. These methods are used like so:

```go
callbackFn := func(cl *mqtt.Client, sub packets.Subscription, pk packets.Packet) {
  // do something ...
}
err = server.Subscribe(cl, "direct/#", 2, callbackFn)
```

and

```go
err := server.Unsubscribe(cl, "direct/#")
```

I have added a new example file, `examples/direct/main.go` which demonstrates the behaviour, and when run, outputs the following:

```
 % go run examples/direct/main.go
11:17PM INF added hook hook=allow-all-auth
11:17PM INF mochi mqtt starting version=2.3.0
11:17PM INF inline client subscribing
11:17PM INF inline client received message from subscription payload="some other retained message" topic=direct/alternate/retained
11:17PM INF mochi mqtt server started
11:17PM INF inline client received message from subscription payload="retained message" topic=direct/retained
11:17PM INF main.go issued direct message to direct/publish
11:17PM INF inline client received message from subscription payload="scheduled message" topic=direct/publish
11:17PM INF main.go issued direct message to direct/publish
11:17PM INF inline client received message from subscription payload="scheduled message" topic=direct/publish
11:17PM INF main.go issued direct message to direct/publish
11:17PM INF inline client received message from subscription payload="scheduled message" topic=direct/publish
11:17PM INF inline client unsubscribing
11:17PM INF main.go issued direct message to direct/publish
11:17PM INF main.go issued direct message to direct/publish
^C11:17PM WRN caught signal, stopping...
11:17PM INF stopping hook hook=allow-all-auth
11:17PM INF mochi mqtt server stopped
11:17PM INF main.go finished
```

There are no tests attached to this PR, but will be added upon acceptance. It also contains a small commit fixing some typos. Feedback encouraged!
