### PR TITLE
feat: return tcp.Address from listener, if exists

### DIFF
--- a/listeners/tcp.go
+++ b/listeners/tcp.go
@@ -44,6 +44,9 @@ func (l *TCP) ID() string {
 
 // Address returns the address of the listener.
 func (l *TCP) Address() string {
+	if l.listen != nil {
+		return l.listen.Addr().String()
+	}
 	return l.address
 }
 


### PR DESCRIPTION
* This is the more accurate and correct address of the listener
* Useful if you want to listen on port 0 to dynamically create listeners (think of unit/integration tests)