### PR TITLE
Handle expired clients in server.loadClients().

### DIFF
--- a/server.go
+++ b/server.go
@@ -1559,7 +1559,6 @@ func (s *Server) loadClients(v []storage.Client) {
 		if expire {
 			cl.ClearInflights()
 			s.UnsubscribeClient(cl)
-			s.Clients.Delete(cl.ID)
 		} else {
 			s.Clients.Add(cl)
 		}

--- a/server_test.go
+++ b/server_test.go
@@ -3128,15 +3128,50 @@ func TestServerLoadClients(t *testing.T) {
 		{ID: "mochi"},
 		{ID: "zen"},
 		{ID: "mochi-co"},
+		{ID: "v3-clean", ProtocolVersion: 4, Clean: true},
+		{ID: "v3-not-clean", ProtocolVersion: 4, Clean: false},
+		{
+			ID: "v5-clean",
+			ProtocolVersion: 5,
+			Clean: true,
+			Properties: storage.ClientProperties{
+				SessionExpiryInterval: 10,
+			},
+		},
+		{
+			ID: "v5-expire-interval-0",
+			ProtocolVersion: 5,
+			Properties: storage.ClientProperties{
+				SessionExpiryInterval: 0,
+			},
+		},
+		{
+			ID: "v5-expire-interval-not-0",
+			ProtocolVersion: 5,
+			Properties: storage.ClientProperties{
+				SessionExpiryInterval: 10,
+			},
+		},
 	}
 
 	s := newServer()
 	require.Equal(t, 0, s.Clients.Len())
 	s.loadClients(v)
-	require.Equal(t, 3, s.Clients.Len())
+	require.Equal(t, 6, s.Clients.Len())
 	cl, ok := s.Clients.Get("mochi")
 	require.True(t, ok)
 	require.Equal(t, "mochi", cl.ID)
+
+	_, ok = s.Clients.Get("v3-clean")
+	require.False(t, ok)
+	_, ok = s.Clients.Get("v3-not-clean")
+	require.True(t, ok)
+	_, ok = s.Clients.Get("v5-clean")
+	require.True(t, ok)
+	_, ok = s.Clients.Get("v5-expire-interval-0")
+	require.False(t, ok)
+	_, ok = s.Clients.Get("v5-expire-interval-not-0")
+	require.True(t, ok)
 }
 
 func TestServerLoadSubscriptions(t *testing.T) {


### PR DESCRIPTION
I encountered a problem similar to #339 . If the broker is forcefully shut down, and clients have the clean flag set, after restarting the broker and calling loadClients(), these expired clients will be retained indefinitely if the client is no longer connected.

It is necessary to handle expired clients in server.loadClients(). Call OnDisconnect() to trigger the hook for clearing persistent clients. Also, if a client has expired, there is no need to retain this client in server.Clients.