### PR TITLE
Fix data race issue with write buffer

### DIFF
--- a/clients.go
+++ b/clients.go
@@ -598,12 +598,7 @@ func (cl *Client) WritePacket(pk packets.Packet) error {
 
 		// there are more writes in the queue
 		if cl.Net.outbuf == nil {
-			if l := buf.Len(); l < cl.ops.options.ClientNetWriteBufferSize {
-				cl.Net.outbuf = buf
-				return int64(l), nil
-			}
-
-			return buf.WriteTo(cl.Net.Conn)
+			cl.Net.outbuf = new(bytes.Buffer)
 		}
 
 		n, _ = buf.WriteTo(cl.Net.outbuf) // will always be successful


### PR DESCRIPTION
Ensure write buffer is not the one used by Hook. As reported in #346.