### PR TITLE
Add MQTT websocket to a custom HTTP server

### DIFF
--- a/clients.go
+++ b/clients.go
@@ -598,10 +598,7 @@ func (cl *Client) WritePacket(pk packets.Packet) error {
 
 		// there are more writes in the queue
 		if cl.Net.outbuf == nil {
-			if l := buf.Len(); l < cl.ops.options.ClientNetWriteBufferSize {
-				cl.Net.outbuf = buf
-				return int64(l), nil
-			}
+			cl.Net.outbuf = new(bytes.Buffer)
 
 			return buf.WriteTo(cl.Net.Conn)
 		}


### PR DESCRIPTION
Add MQTT websocket to a custom HTTP server

```go
func main() {
        router := gin.Default()
	ginServer := &http.Server{
		Addr:    ":13000",
		Handler: router,
                 ReadTimeout:    10 * time.Second,
		WriteTimeout:   10 * time.Second,
		MaxHeaderBytes: 1 << 20,
	}
        server := mqtt.New(nil)
	_ = server.AddHook(new(auth.AllowHook), nil)
	ws := listeners.WebsocketFromHTTPServer("websocket", ginServer)
	if err := server.AddListener(ws); err != nil {
		log.Error(err.Error())
	}
	go func() {
		err := server.Serve()
		if err != nil {
			log.Error(err.Error())
		}
	}()
	router.GET("/socket", func(c *gin.Context) {
		ws.Handler(c.Writer, c.Request)
	})
	ginServer.ListenAndServe()
}
```