### PR TITLE
Implement File based configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,3 +19,4 @@ WORKDIR /
 COPY --from=builder /app/mochi .
 
 ENTRYPOINT [ "/mochi" ]
+CMD ["/cmd/docker", "--config", "config.yaml"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,21 +11,11 @@ RUN go mod download
 
 COPY . ./
 
-RUN go build -o /app/mochi ./cmd
-
+RUN go build -o /app/mochi ./cmd/docker
 
 FROM alpine
 
 WORKDIR /
 COPY --from=builder /app/mochi .
-
-# tcp
-EXPOSE 1883
-
-# websockets
-EXPOSE 1882
-
-# dashboard
-EXPOSE 8080
 
 ENTRYPOINT [ "/mochi" ]

--- a/clients.go
+++ b/clients.go
@@ -215,6 +215,10 @@ func (cl *Client) ParseConnect(lid string, pk packets.Packet) {
 	cl.Properties.Clean = pk.Connect.Clean
 	cl.Properties.Props = pk.Properties.Copy(false)
 
+	if cl.Properties.Props.ReceiveMaximum > cl.ops.options.Capabilities.MaximumInflight { // 3.3.4 Non-normative
+		cl.Properties.Props.ReceiveMaximum = cl.ops.options.Capabilities.MaximumInflight
+	}
+
 	if pk.Connect.Keepalive <= minimumKeepalive {
 		cl.ops.log.Warn(
 			ErrMinimumKeepalive.Error(),

--- a/cmd/docker/main.go
+++ b/cmd/docker/main.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2023 mochi-mqtt
+// SPDX-FileContributor: dgduncan, mochi-co
+
+package main
+
+import (
+	"flag"
+	"github.com/mochi-mqtt/server/v2/config"
+	"log"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+
+	mqtt "github.com/mochi-mqtt/server/v2"
+)
+
+func main() {
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stdout, nil))) // set basic logger to ensure logs before configuration are in a consistent format
+
+	configFile := flag.String("config", "config.yaml", "path to mochi config yaml or json file")
+	flag.Parse()
+
+	sigs := make(chan os.Signal, 1)
+	done := make(chan bool, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigs
+		done <- true
+	}()
+
+	configBytes, err := os.ReadFile(*configFile)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	options, err := config.FromBytes(configBytes)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	server := mqtt.New(options)
+
+	go func() {
+		err := server.Serve()
+		if err != nil {
+			log.Fatal(err)
+		}
+	}()
+
+	<-done
+	server.Log.Warn("caught signal, stopping...")
+	_ = server.Close()
+	server.Log.Info("mochi mqtt shutdown complete")
+}

--- a/cmd/docker/main.go
+++ b/cmd/docker/main.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"github.com/mochi-mqtt/server/v2/config"
 	"log"
 	"log/slog"
@@ -21,6 +22,15 @@ func main() {
 
 	configFile := flag.String("config", "config.yaml", "path to mochi config yaml or json file")
 	flag.Parse()
+
+	entries, err := os.ReadDir("./")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, e := range entries {
+		fmt.Println(e.Name())
+	}
 
 	sigs := make(chan os.Signal, 1)
 	done := make(chan bool, 1)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -33,19 +33,31 @@ func main() {
 	server := mqtt.New(nil)
 	_ = server.AddHook(new(auth.AllowHook), nil)
 
-	tcp := listeners.NewTCP("t1", *tcpAddr, nil)
+	tcp := listeners.NewTCP(listeners.Config{
+		ID:      "t1",
+		Address: *tcpAddr,
+	})
 	err := server.AddListener(tcp)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	ws := listeners.NewWebsocket("ws1", *wsAddr, nil)
+	ws := listeners.NewWebsocket(listeners.Config{
+		ID:      "ws1",
+		Address: *wsAddr,
+	})
 	err = server.AddListener(ws)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	stats := listeners.NewHTTPStats("stats", *infoAddr, nil, server.Info)
+	stats := listeners.NewHTTPStats(
+		listeners.Config{
+			ID:      "info",
+			Address: *infoAddr,
+		},
+		server.Info,
+	)
 	err = server.AddListener(stats)
 	if err != nil {
 		log.Fatal(err)
@@ -61,6 +73,5 @@ func main() {
 	<-done
 	server.Log.Warn("caught signal, stopping...")
 	_ = server.Close()
-	server.Log.Info("main.go finished")
-
+	server.Log.Info("mochi mqtt shutdown complete")
 }

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,15 @@
+listeners:
+  - type: "tcp"
+    id: "tcp1"
+    address: ":1883"
+  - type: "ws"
+    id: "ws1"
+    address: ":1882"
+  - type: "sysinfo"
+    id: "stats"
+    address: ":1880"
+hooks:
+  auth:
+    allow_all: true
+options:
+  inline_client: true

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 listeners:
   - type: "tcp"
-    id: "tcp1"
+    id: "tcp12"
     address: ":1883"
   - type: "ws"
     id: "ws1"

--- a/config/config.go
+++ b/config/config.go
@@ -17,29 +17,34 @@ import (
 	mqtt "github.com/mochi-mqtt/server/v2"
 )
 
+// config defines the structure of configuration data to be parsed from a config source.
 type config struct {
 	Options     mqtt.Options
 	Listeners   []listeners.Config `yaml:"listeners" json:"listeners"`
 	HookConfigs HookConfigs        `yaml:"hooks" json:"hooks"`
 }
 
+// HookConfigs contains configurations to enable individual hooks.
 type HookConfigs struct {
 	Auth    *HookAuthConfig    `yaml:"auth" json:"auth"`
 	Storage *HookStorageConfig `yaml:"storage" json:"storage"`
 	Debug   *debug.Options     `yaml:"debug" json:"debug"`
 }
 
+// HookAuthConfig contains configurations for the auth hook.
 type HookAuthConfig struct {
 	Ledger   auth.Ledger `yaml:"ledger" json:"ledger"`
 	AllowAll bool        `yaml:"allow_all" json:"allow_all"`
 }
 
+// HookStorageConfig contains configurations for the different storage hooks.
 type HookStorageConfig struct {
 	Badger *badger.Options `yaml:"badger" json:"badger"`
 	Bolt   *bolt.Options   `yaml:"bolt" json:"bolt"`
 	Redis  *redis.Options  `yaml:"redis" json:"redis"`
 }
 
+// ToHooks converts Hook file configurations into Hooks to be added to the server.
 func (hc HookConfigs) ToHooks() []mqtt.HookLoadConfig {
 	var hlc []mqtt.HookLoadConfig
 
@@ -61,6 +66,7 @@ func (hc HookConfigs) ToHooks() []mqtt.HookLoadConfig {
 	return hlc
 }
 
+// toHooksAuth converts auth hook configurations into auth hooks.
 func (hc HookConfigs) toHooksAuth() []mqtt.HookLoadConfig {
 	var hlc []mqtt.HookLoadConfig
 	if hc.Auth.AllowAll {
@@ -82,6 +88,7 @@ func (hc HookConfigs) toHooksAuth() []mqtt.HookLoadConfig {
 	return hlc
 }
 
+// toHooksAuth converts storage hook configurations into storage hooks.
 func (hc HookConfigs) toHooksStorage() []mqtt.HookLoadConfig {
 	var hlc []mqtt.HookLoadConfig
 	if hc.Storage.Badger != nil {
@@ -107,6 +114,8 @@ func (hc HookConfigs) toHooksStorage() []mqtt.HookLoadConfig {
 	return hlc
 }
 
+// FromBytes unmarshals a byte slice of JSON or YAML config data into a valid server options value.
+// Any hooks configurations are converted into Hooks using the toHooks methods in this package.
 func FromBytes(b []byte) (*mqtt.Options, error) {
 	c := new(config)
 	o := mqtt.Options{}

--- a/config/config.go
+++ b/config/config.go
@@ -53,7 +53,7 @@ func (hc HookConfigs) ToHooks() []mqtt.HookLoadConfig {
 	}
 
 	if hc.Storage != nil {
-		hlc = append(hlc, hc.toHooksAuth()...)
+		hlc = append(hlc, hc.toHooksStorage()...)
 	}
 
 	if hc.Debug != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2023 mochi-mqtt, mochi-co
+// SPDX-FileContributor: mochi-co
+
+package config
+
+import (
+	"encoding/json"
+	"github.com/mochi-mqtt/server/v2/hooks/auth"
+	"github.com/mochi-mqtt/server/v2/hooks/debug"
+	"github.com/mochi-mqtt/server/v2/hooks/storage/badger"
+	"github.com/mochi-mqtt/server/v2/hooks/storage/bolt"
+	"github.com/mochi-mqtt/server/v2/hooks/storage/redis"
+	"github.com/mochi-mqtt/server/v2/listeners"
+	"gopkg.in/yaml.v3"
+
+	mqtt "github.com/mochi-mqtt/server/v2"
+)
+
+type config struct {
+	Options     mqtt.Options
+	Listeners   []listeners.Config `yaml:"listeners" json:"listeners"`
+	HookConfigs HookConfigs        `yaml:"hooks" json:"hooks"`
+}
+
+type HookConfigs struct {
+	Auth    *HookAuthConfig    `yaml:"auth" json:"auth"`
+	Storage *HookStorageConfig `yaml:"storage" json:"storage"`
+	Debug   *debug.Options     `yaml:"debug" json:"debug"`
+}
+
+type HookAuthConfig struct {
+	Ledger   auth.Ledger `yaml:"ledger" json:"ledger"`
+	AllowAll bool        `yaml:"allow_all" json:"allow_all"`
+}
+
+type HookStorageConfig struct {
+	Badger *badger.Options `yaml:"badger" json:"badger"`
+	Bolt   *bolt.Options   `yaml:"bolt" json:"bolt"`
+	Redis  *redis.Options  `yaml:"redis" json:"redis"`
+}
+
+func (hc HookConfigs) ToHooks() []mqtt.HookLoadConfig {
+	var hlc []mqtt.HookLoadConfig
+
+	if hc.Auth != nil {
+		hlc = append(hlc, hc.toHooksAuth()...)
+	}
+
+	if hc.Storage != nil {
+		hlc = append(hlc, hc.toHooksAuth()...)
+	}
+
+	if hc.Debug != nil {
+		hlc = append(hlc, mqtt.HookLoadConfig{
+			Hook:   new(debug.Hook),
+			Config: hc.Debug,
+		})
+	}
+
+	return hlc
+}
+
+func (hc HookConfigs) toHooksAuth() []mqtt.HookLoadConfig {
+	var hlc []mqtt.HookLoadConfig
+	if hc.Auth.AllowAll {
+		hlc = append(hlc, mqtt.HookLoadConfig{
+			Hook: new(auth.AllowHook),
+		})
+	} else {
+		hlc = append(hlc, mqtt.HookLoadConfig{
+			Hook: new(auth.Hook),
+			Config: &auth.Options{
+				Ledger: &auth.Ledger{ // avoid copying sync.Locker
+					Users: hc.Auth.Ledger.Users,
+					Auth:  hc.Auth.Ledger.Auth,
+					ACL:   hc.Auth.Ledger.ACL,
+				},
+			},
+		})
+	}
+	return hlc
+}
+
+func (hc HookConfigs) toHooksStorage() []mqtt.HookLoadConfig {
+	var hlc []mqtt.HookLoadConfig
+	if hc.Storage.Badger != nil {
+		hlc = append(hlc, mqtt.HookLoadConfig{
+			Hook:   new(badger.Hook),
+			Config: hc.Storage.Badger,
+		})
+	}
+
+	if hc.Storage.Bolt != nil {
+		hlc = append(hlc, mqtt.HookLoadConfig{
+			Hook:   new(bolt.Hook),
+			Config: hc.Storage.Bolt,
+		})
+	}
+
+	if hc.Storage.Redis != nil {
+		hlc = append(hlc, mqtt.HookLoadConfig{
+			Hook:   new(redis.Hook),
+			Config: hc.Storage.Redis,
+		})
+	}
+	return hlc
+}
+
+func FromBytes(b []byte) (*mqtt.Options, error) {
+	c := new(config)
+	o := mqtt.Options{}
+
+	if len(b) == 0 {
+		return nil, nil
+	}
+
+	if b[0] == '{' {
+		err := json.Unmarshal(b, c)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		err := yaml.Unmarshal(b, c)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	o = c.Options
+	o.Hooks = c.HookConfigs.ToHooks()
+	o.Listeners = c.Listeners
+
+	return &o, nil
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2023 mochi-mqtt, mochi-co
+// SPDX-FileContributor: mochi-co
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mochi-mqtt/server/v2/hooks/auth"
+	"github.com/mochi-mqtt/server/v2/hooks/storage/badger"
+	"github.com/mochi-mqtt/server/v2/hooks/storage/bolt"
+	"github.com/mochi-mqtt/server/v2/hooks/storage/redis"
+	"github.com/mochi-mqtt/server/v2/listeners"
+
+	mqtt "github.com/mochi-mqtt/server/v2"
+)
+
+var (
+	yamlBytes = []byte(`
+listeners:
+  - type: "tcp"
+    id: "file-tcp1"
+    address: ":1883"
+hooks:
+  auth:
+    allow_all: true
+options:
+  client_net_write_buffer_size: 2048
+  capabilities:
+    minimum_protocol_version: 3
+    compatibilities:
+      restore_sys_info_on_restart: true
+`)
+
+	jsonBytes = []byte(`{
+   "listeners": [
+      {
+         "type": "tcp",
+         "id": "file-tcp1",
+         "address": ":1883"
+      }
+   ],
+   "hooks": {
+      "auth": {
+         "allow_all": true
+      }
+   },
+   "options": {
+      "client_net_write_buffer_size": 2048,
+      "capabilities": {
+         "minimum_protocol_version": 3,
+         "compatibilities": {
+            "restore_sys_info_on_restart": true
+         }
+      }
+   }
+}
+`)
+
+	parsedOptions = mqtt.Options{
+		Listeners: []listeners.Config{
+			{
+				Type:    listeners.TypeTCP,
+				ID:      "file-tcp1",
+				Address: ":1883",
+			},
+		},
+		Hooks: []mqtt.HookLoadConfig{
+			{
+				Hook: new(auth.AllowHook),
+			},
+		},
+		ClientNetWriteBufferSize: 2048,
+		Capabilities: &mqtt.Capabilities{
+			MinimumProtocolVersion: 3,
+			Compatibilities: mqtt.Compatibilities{
+				RestoreSysInfoOnRestart: true,
+			},
+		},
+	}
+)
+
+func TestFromBytesEmptyL(t *testing.T) {
+	_, err := FromBytes([]byte{})
+	require.NoError(t, err)
+}
+
+func TestFromBytesYAML(t *testing.T) {
+	o, err := FromBytes(yamlBytes)
+	require.NoError(t, err)
+	require.Equal(t, parsedOptions, *o)
+}
+
+func TestFromBytesYAMLError(t *testing.T) {
+	_, err := FromBytes(append(yamlBytes, 'a'))
+	require.Error(t, err)
+}
+
+func TestFromBytesJSON(t *testing.T) {
+	o, err := FromBytes(jsonBytes)
+	require.NoError(t, err)
+	require.Equal(t, parsedOptions, *o)
+}
+
+func TestFromBytesJSONError(t *testing.T) {
+	_, err := FromBytes(append(jsonBytes, 'a'))
+	require.Error(t, err)
+}
+
+func TestToHooksAuthAllowAll(t *testing.T) {
+	hc := HookConfigs{
+		Auth: &HookAuthConfig{
+			AllowAll: true,
+		},
+	}
+
+	th := hc.toHooksAuth()
+	expect := []mqtt.HookLoadConfig{
+		{Hook: new(auth.AllowHook)},
+	}
+	require.Equal(t, expect, th)
+}
+
+func TestToHooksAuthAllowLedger(t *testing.T) {
+	hc := HookConfigs{
+		Auth: &HookAuthConfig{
+			Ledger: auth.Ledger{
+				Auth: auth.AuthRules{
+					{Username: "peach", Password: "password1", Allow: true},
+				},
+			},
+		},
+	}
+
+	th := hc.toHooksAuth()
+	expect := []mqtt.HookLoadConfig{
+		{
+			Hook: new(auth.Hook),
+			Config: &auth.Options{
+				Ledger: &auth.Ledger{ // avoid copying sync.Locker
+					Auth: auth.AuthRules{
+						{Username: "peach", Password: "password1", Allow: true},
+					},
+				},
+			},
+		},
+	}
+	require.Equal(t, expect, th)
+}
+
+func TestToHooksStorageBadger(t *testing.T) {
+	hc := HookConfigs{
+		Storage: &HookStorageConfig{
+			Badger: &badger.Options{
+				Path: "badger",
+			},
+		},
+	}
+
+	th := hc.toHooksStorage()
+	expect := []mqtt.HookLoadConfig{
+		{
+			Hook:   new(badger.Hook),
+			Config: hc.Storage.Badger,
+		},
+	}
+
+	require.Equal(t, expect, th)
+}
+
+func TestToHooksStorageBolt(t *testing.T) {
+	hc := HookConfigs{
+		Storage: &HookStorageConfig{
+			Bolt: &bolt.Options{
+				Path: "bolt",
+			},
+		},
+	}
+
+	th := hc.toHooksStorage()
+	expect := []mqtt.HookLoadConfig{
+		{
+			Hook:   new(bolt.Hook),
+			Config: hc.Storage.Bolt,
+		},
+	}
+
+	require.Equal(t, expect, th)
+}
+
+func TestToHooksStorageRedis(t *testing.T) {
+	hc := HookConfigs{
+		Storage: &HookStorageConfig{
+			Redis: &redis.Options{
+				Username: "test",
+			},
+		},
+	}
+
+	th := hc.toHooksStorage()
+	expect := []mqtt.HookLoadConfig{
+		{
+			Hook:   new(redis.Hook),
+			Config: hc.Storage.Redis,
+		},
+	}
+
+	require.Equal(t, expect, th)
+}

--- a/examples/auth/basic/main.go
+++ b/examples/auth/basic/main.go
@@ -63,7 +63,10 @@ func main() {
 		log.Fatal(err)
 	}
 
-	tcp := listeners.NewTCP("t1", ":1883", nil)
+	tcp := listeners.NewTCP(listeners.Config{
+		ID:      "t1",
+		Address: ":1883",
+	})
 	err = server.AddListener(tcp)
 	if err != nil {
 		log.Fatal(err)

--- a/examples/auth/encoded/main.go
+++ b/examples/auth/encoded/main.go
@@ -45,7 +45,10 @@ func main() {
 		log.Fatal(err)
 	}
 
-	tcp := listeners.NewTCP("t1", ":1883", nil)
+	tcp := listeners.NewTCP(listeners.Config{
+		ID:      "t1",
+		Address: ":1883",
+	})
 	err = server.AddListener(tcp)
 	if err != nil {
 		log.Fatal(err)

--- a/examples/benchmark/main.go
+++ b/examples/benchmark/main.go
@@ -32,7 +32,10 @@ func main() {
 	server.Options.Capabilities.MaximumClientWritesPending = 16 * 1024
 	_ = server.AddHook(new(auth.AllowHook), nil)
 
-	tcp := listeners.NewTCP("t1", *tcpAddr, nil)
+	tcp := listeners.NewTCP(listeners.Config{
+		ID:      "t1",
+		Address: *tcpAddr,
+	})
 	err := server.AddListener(tcp)
 	if err != nil {
 		log.Fatal(err)

--- a/examples/config/config.json
+++ b/examples/config/config.json
@@ -70,6 +70,7 @@
       "maximum_session_expiry_interval": 86400,
       "maximum_packet_size": 0,
       "receive_maximum": 1024,
+      "maximum_inflight": 8192,
       "topic_alias_maximum": 65535,
       "shared_sub_available": 1,
       "minimum_protocol_version": 3,

--- a/examples/config/config.json
+++ b/examples/config/config.json
@@ -1,0 +1,88 @@
+{
+  "listeners": [
+    {
+      "type": "tcp",
+      "id": "file-tcp1",
+      "address": ":1883"
+    },
+    {
+      "type": "ws",
+      "id": "file-websocket",
+      "address": ":1882"
+    },
+    {
+      "type": "healthcheck",
+      "id": "file-healthcheck",
+      "address": ":1880"
+    }
+  ],
+  "hooks": {
+    "debug": {
+      "enable": true
+    },
+    "storage": {
+      "badger": {
+        "path": "badger.db"
+      },
+      "bolt": {
+        "path": "bolt.db"
+      },
+      "redis": {
+        "h_prefix": "mc",
+        "username": "mochi",
+        "password": "melon",
+        "address": "localhost:6379",
+        "database": 1
+      }
+    },
+    "auth": {
+      "ledger": {
+        "auth": [
+          {
+            "username": "peach",
+            "password": "password1",
+            "allow": true
+          }
+        ],
+        "acl": [
+          {
+            "remote": "127.0.0.1:*"
+          },
+          {
+            "username": "melon",
+            "filters": null,
+            "melon/#": 3,
+            "updates/#": 2
+          }
+        ]
+      }
+    }
+  },
+  "options": {
+    "client_net_write_buffer_size": 2048,
+    "client_net_read_buffer_size": 2048,
+    "sys_topic_resend_interval": 10,
+    "inline_client": true,
+    "capabilities": {
+      "maximum_message_expiry_interval": 100,
+      "maximum_client_writes_pending": 8192,
+      "maximum_session_expiry_interval": 86400,
+      "maximum_packet_size": 0,
+      "receive_maximum": 1024,
+      "topic_alias_maximum": 65535,
+      "shared_sub_available": 1,
+      "minimum_protocol_version": 3,
+      "maximum_qos": 2,
+      "retain_available": 1,
+      "wildcard_sub_available": 1,
+      "sub_id_available": 1,
+      "compatibilities": {
+        "obscure_not_authorized": true,
+        "passive_client_disconnect": false,
+        "always_return_response_info": false,
+        "restore_sys_info_on_restart": false,
+        "no_inherited_properties_on_ack": false
+      }
+    }
+  }
+}

--- a/examples/config/config.json
+++ b/examples/config/config.json
@@ -36,6 +36,7 @@
       }
     },
     "auth": {
+      "allow_all": false,
       "ledger": {
         "auth": [
           {

--- a/examples/config/config.yaml
+++ b/examples/config/config.yaml
@@ -46,6 +46,7 @@ options:
     maximum_session_expiry_interval: 86400
     maximum_packet_size: 0
     receive_maximum: 1024
+    maximum_inflight: 8192
     topic_alias_maximum: 65535
     shared_sub_available: 1
     minimum_protocol_version: 3

--- a/examples/config/config.yaml
+++ b/examples/config/config.yaml
@@ -23,6 +23,7 @@ hooks:
       address: "localhost:6379"
       database: 1
   auth:
+    allow_all: false
     ledger:
       auth:
         - username: peach

--- a/examples/config/config.yaml
+++ b/examples/config/config.yaml
@@ -1,0 +1,60 @@
+listeners:
+  - type: "tcp"
+    id: "file-tcp1"
+    address: ":1883"
+  - type: "ws"
+    id: "file-websocket"
+    address: ":1882"
+  - type: "healthcheck"
+    id: "file-healthcheck"
+    address: ":1880"
+hooks:
+  debug:
+    enable: true
+  storage:
+    badger:
+      path: badger.db
+    bolt:
+      path: bolt.db
+    redis:
+      h_prefix: "mc"
+      username: "mochi"
+      password: "melon"
+      address: "localhost:6379"
+      database: 1
+  auth:
+    ledger:
+      auth:
+        - username: peach
+          password: password1
+          allow: true
+      acl:
+        - remote: 127.0.0.1:*
+        - username: melon
+          filters:
+          melon/#: 3
+          updates/#: 2
+options:
+  client_net_write_buffer_size: 2048
+  client_net_read_buffer_size: 2048
+  sys_topic_resend_interval: 10
+  inline_client: true
+  capabilities:
+    maximum_message_expiry_interval: 100
+    maximum_client_writes_pending: 8192
+    maximum_session_expiry_interval: 86400
+    maximum_packet_size: 0
+    receive_maximum: 1024
+    topic_alias_maximum: 65535
+    shared_sub_available: 1
+    minimum_protocol_version: 3
+    maximum_qos: 2
+    retain_available: 1
+    wildcard_sub_available: 1
+    sub_id_available: 1
+    compatibilities:
+      obscure_not_authorized: true
+      passive_client_disconnect: false
+      always_return_response_info: false
+      restore_sys_info_on_restart: false
+      no_inherited_properties_on_ack: false

--- a/examples/config/main.go
+++ b/examples/config/main.go
@@ -23,7 +23,7 @@ func main() {
 		done <- true
 	}()
 
-	configBytes, err := os.ReadFile("config.yaml")
+	configBytes, err := os.ReadFile("config.json")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/config/main.go
+++ b/examples/config/main.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2022 mochi-mqtt, mochi-co
+// SPDX-FileCopyrightText: 2023 mochi-mqtt, mochi-co
 // SPDX-FileContributor: mochi-co
 
 package main

--- a/examples/hooks/main.go
+++ b/examples/hooks/main.go
@@ -33,7 +33,10 @@ func main() {
 	})
 
 	_ = server.AddHook(new(auth.AllowHook), nil)
-	tcp := listeners.NewTCP("t1", ":1883", nil)
+	tcp := listeners.NewTCP(listeners.Config{
+		ID:      "t1",
+		Address: ":1883",
+	})
 	err := server.AddListener(tcp)
 	if err != nil {
 		log.Fatal(err)

--- a/examples/paho.testing/main.go
+++ b/examples/paho.testing/main.go
@@ -31,7 +31,10 @@ func main() {
 	server.Options.Capabilities.Compatibilities.NoInheritedPropertiesOnAck = true
 
 	_ = server.AddHook(new(pahoAuthHook), nil)
-	tcp := listeners.NewTCP("t1", ":1883", nil)
+	tcp := listeners.NewTCP(listeners.Config{
+		ID:      "t1",
+		Address: ":1883",
+	})
 	err := server.AddListener(tcp)
 	if err != nil {
 		log.Fatal(err)

--- a/examples/persistence/badger/main.go
+++ b/examples/persistence/badger/main.go
@@ -38,7 +38,10 @@ func main() {
 		log.Fatal(err)
 	}
 
-	tcp := listeners.NewTCP("t1", ":1883", nil)
+	tcp := listeners.NewTCP(listeners.Config{
+		ID:      "t1",
+		Address: ":1883",
+	})
 	err = server.AddListener(tcp)
 	if err != nil {
 		log.Fatal(err)

--- a/examples/persistence/badger/main.go
+++ b/examples/persistence/badger/main.go
@@ -5,18 +5,16 @@
 package main
 
 import (
-	"log"
-	"os"
-	"os/signal"
-	"syscall"
-	"time"
-
 	badgerdb "github.com/dgraph-io/badger"
 	mqtt "github.com/mochi-mqtt/server/v2"
 	"github.com/mochi-mqtt/server/v2/hooks/auth"
 	"github.com/mochi-mqtt/server/v2/hooks/storage/badger"
 	"github.com/mochi-mqtt/server/v2/listeners"
 	"github.com/timshannon/badgerhold"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
 )
 
 func main() {
@@ -38,10 +36,10 @@ func main() {
 	// GcInterval specifies the interval at which BadgerDB garbage collection process runs.
 	// Refer to https://dgraph.io/docs/badger/get-started/#garbage-collection for more information.
 	err := server.AddHook(new(badger.Hook), &badger.Options{
-		Path:       badgerPath,
+		Path: badgerPath,
 
 		// Set the interval for garbage collection. Adjust according to your actual scenario.
-		GcInterval: 5 * time.Minute, 
+		GcInterval: 5 * 60,
 
 		// GcDiscardRatio specifies the ratio of log discard compared to the maximum possible log discard.
 		// Setting it to a higher value would result in fewer space reclaims, while setting it to a lower value

--- a/examples/persistence/bolt/main.go
+++ b/examples/persistence/bolt/main.go
@@ -40,7 +40,10 @@ func main() {
 		log.Fatal(err)
 	}
 
-	tcp := listeners.NewTCP("t1", ":1883", nil)
+	tcp := listeners.NewTCP(listeners.Config{
+		ID:      "t1",
+		Address: ":1883",
+	})
 	err = server.AddListener(tcp)
 	if err != nil {
 		log.Fatal(err)

--- a/examples/persistence/redis/main.go
+++ b/examples/persistence/redis/main.go
@@ -48,7 +48,10 @@ func main() {
 		log.Fatal(err)
 	}
 
-	tcp := listeners.NewTCP("t1", ":1883", nil)
+	tcp := listeners.NewTCP(listeners.Config{
+		ID:      "t1",
+		Address: ":1883",
+	})
 	err = server.AddListener(tcp)
 	if err != nil {
 		log.Fatal(err)

--- a/examples/tcp/main.go
+++ b/examples/tcp/main.go
@@ -38,7 +38,10 @@ func main() {
 		log.Fatal(err)
 	}
 
-	tcp := listeners.NewTCP("t1", ":1883", nil)
+	tcp := listeners.NewTCP(listeners.Config{
+		ID:      "t1",
+		Address: ":1883",
+	})
 	err = server.AddListener(tcp)
 	if err != nil {
 		log.Fatal(err)

--- a/examples/tls/main.go
+++ b/examples/tls/main.go
@@ -79,7 +79,9 @@ func main() {
 	server := mqtt.New(nil)
 	_ = server.AddHook(new(auth.AllowHook), nil)
 
-	tcp := listeners.NewTCP("t1", ":1883", &listeners.Config{
+	tcp := listeners.NewTCP(listeners.Config{
+		ID:        "t1",
+		Address:   ":1883",
 		TLSConfig: tlsConfig,
 	})
 	err = server.AddListener(tcp)
@@ -87,7 +89,9 @@ func main() {
 		log.Fatal(err)
 	}
 
-	ws := listeners.NewWebsocket("ws1", ":1882", &listeners.Config{
+	ws := listeners.NewWebsocket(listeners.Config{
+		ID:        "ws1",
+		Address:   ":1882",
 		TLSConfig: tlsConfig,
 	})
 	err = server.AddListener(ws)
@@ -95,9 +99,13 @@ func main() {
 		log.Fatal(err)
 	}
 
-	stats := listeners.NewHTTPStats("stats", ":8080", &listeners.Config{
-		TLSConfig: tlsConfig,
-	}, server.Info)
+	stats := listeners.NewHTTPStats(
+		listeners.Config{
+			ID:        "stats",
+			Address:   ":8080",
+			TLSConfig: tlsConfig,
+		}, server.Info,
+	)
 	err = server.AddListener(stats)
 	if err != nil {
 		log.Fatal(err)

--- a/examples/websocket/main.go
+++ b/examples/websocket/main.go
@@ -27,7 +27,10 @@ func main() {
 	server := mqtt.New(nil)
 	_ = server.AddHook(new(auth.AllowHook), nil)
 
-	ws := listeners.NewWebsocket("ws1", ":1882", nil)
+	ws := listeners.NewWebsocket(listeners.Config{
+		ID:      "ws1",
+		Address: ":1882",
+	})
 	err := server.AddListener(ws)
 	if err != nil {
 		log.Fatal(err)

--- a/hooks.go
+++ b/hooks.go
@@ -62,6 +62,11 @@ var (
 	ErrInvalidConfigType = errors.New("invalid config type provided")
 )
 
+type HookLoadConfig struct {
+	Hook   Hook
+	Config any
+}
+
 // Hook provides an interface of handlers for different events which occur
 // during the lifecycle of the broker.
 type Hook interface {
@@ -70,6 +75,7 @@ type Hook interface {
 	Init(config any) error
 	Stop() error
 	SetOpts(l *slog.Logger, o *HookOptions)
+
 	OnStarted()
 	OnStopped()
 	OnConnectAuthenticate(cl *Client, pk packets.Packet) bool

--- a/hooks.go
+++ b/hooks.go
@@ -62,6 +62,7 @@ var (
 	ErrInvalidConfigType = errors.New("invalid config type provided")
 )
 
+// HookLoadConfig contains the hook and configuration as loaded from a configuration (usually file).
 type HookLoadConfig struct {
 	Hook   Hook
 	Config any

--- a/hooks/debug/debug.go
+++ b/hooks/debug/debug.go
@@ -16,9 +16,10 @@ import (
 
 // Options contains configuration settings for the debug output.
 type Options struct {
-	ShowPacketData bool // include decoded packet data (default false)
-	ShowPings      bool // show ping requests and responses (default false)
-	ShowPasswords  bool // show connecting user passwords (default false)
+	Enable         bool `yaml:"enable" json:"enable"`                     // non-zero field for enabling hook using file-based config
+	ShowPacketData bool `yaml:"show_packet_data" json:"show_packet_data"` // include decoded packet data (default false)
+	ShowPings      bool `yaml:"show_pings" json:"show_pings"`             // show ping requests and responses (default false)
+	ShowPasswords  bool `yaml:"show_passwords" json:"show_passwords"`     // show connecting user passwords (default false)
 }
 
 // Hook is a debugging hook which logs additional low-level information from the server.

--- a/hooks/storage/badger/badger.go
+++ b/hooks/storage/badger/badger.go
@@ -51,7 +51,7 @@ func sysInfoKey() string {
 // Options contains configuration settings for the BadgerDB instance.
 type Options struct {
 	Options *badgerhold.Options
-	Path    string
+	Path    string `yaml:"path" json:"path"`
 }
 
 // Hook is a persistent storage hook based using BadgerDB file store as a backend.

--- a/hooks/storage/bolt/bolt.go
+++ b/hooks/storage/bolt/bolt.go
@@ -56,7 +56,7 @@ func sysInfoKey() string {
 // Options contains configuration settings for the bolt instance.
 type Options struct {
 	Options *bbolt.Options
-	Path    string
+	Path    string `yaml:"path" json:"path"`
 }
 
 // Hook is a persistent storage hook based using boltdb file store as a backend.

--- a/hooks/storage/redis/redis_test.go
+++ b/hooks/storage/redis/redis_test.go
@@ -135,6 +135,29 @@ func TestInitUseDefaults(t *testing.T) {
 	require.Equal(t, defaultAddr, h.config.Options.Addr)
 }
 
+func TestInitUsePassConfig(t *testing.T) {
+	s := miniredis.RunT(t)
+	s.StartAddr(defaultAddr)
+	defer s.Close()
+
+	h := newHook(t, "")
+	h.SetOpts(logger, nil)
+
+	err := h.Init(&Options{
+		Address:  defaultAddr,
+		Username: "username",
+		Password: "password",
+		Database: 2,
+	})
+	require.Error(t, err)
+	h.db.FlushAll(h.ctx)
+
+	require.Equal(t, defaultAddr, h.config.Options.Addr)
+	require.Equal(t, "username", h.config.Options.Username)
+	require.Equal(t, "password", h.config.Options.Password)
+	require.Equal(t, 2, h.config.Options.DB)
+}
+
 func TestInitBadConfig(t *testing.T) {
 	h := new(Hook)
 	h.SetOpts(logger, nil)

--- a/listeners/http_healthcheck.go
+++ b/listeners/http_healthcheck.go
@@ -13,24 +13,23 @@ import (
 	"time"
 )
 
+const TypeHealthCheck = "healthcheck"
+
 // HTTPHealthCheck is a listener for providing an HTTP healthcheck endpoint.
 type HTTPHealthCheck struct {
 	sync.RWMutex
 	id      string       // the internal id of the listener
 	address string       // the network address to bind to
-	config  *Config      // configuration values for the listener
+	config  Config       // configuration values for the listener
 	listen  *http.Server // the http server
 	end     uint32       // ensure the close methods are only called once
 }
 
-// NewHTTPHealthCheck initialises and returns a new HTTP listener, listening on an address.
-func NewHTTPHealthCheck(id, address string, config *Config) *HTTPHealthCheck {
-	if config == nil {
-		config = new(Config)
-	}
+// NewHTTPHealthCheck initializes and returns a new HTTP listener, listening on an address.
+func NewHTTPHealthCheck(config Config) *HTTPHealthCheck {
 	return &HTTPHealthCheck{
-		id:      id,
-		address: address,
+		id:      config.ID,
+		address: config.Address,
 		config:  config,
 	}
 }

--- a/listeners/http_healthcheck_test.go
+++ b/listeners/http_healthcheck_test.go
@@ -14,47 +14,44 @@ import (
 )
 
 func TestNewHTTPHealthCheck(t *testing.T) {
-	l := NewHTTPHealthCheck("healthcheck", testAddr, nil)
-	require.Equal(t, "healthcheck", l.id)
-	require.Equal(t, testAddr, l.address)
+	l := NewHTTPHealthCheck(basicConfig)
+	require.Equal(t, basicConfig.ID, l.id)
+	require.Equal(t, basicConfig.Address, l.address)
 }
 
 func TestHTTPHealthCheckID(t *testing.T) {
-	l := NewHTTPHealthCheck("healthcheck", testAddr, nil)
-	require.Equal(t, "healthcheck", l.ID())
+	l := NewHTTPHealthCheck(basicConfig)
+	require.Equal(t, basicConfig.ID, l.ID())
 }
 
 func TestHTTPHealthCheckAddress(t *testing.T) {
-	l := NewHTTPHealthCheck("healthcheck", testAddr, nil)
-	require.Equal(t, testAddr, l.Address())
+	l := NewHTTPHealthCheck(basicConfig)
+	require.Equal(t, basicConfig.Address, l.Address())
 }
 
 func TestHTTPHealthCheckProtocol(t *testing.T) {
-	l := NewHTTPHealthCheck("healthcheck", testAddr, nil)
+	l := NewHTTPHealthCheck(basicConfig)
 	require.Equal(t, "http", l.Protocol())
 }
 
 func TestHTTPHealthCheckTLSProtocol(t *testing.T) {
-	l := NewHTTPHealthCheck("healthcheck", testAddr, &Config{
-		TLSConfig: tlsConfigBasic,
-	})
-
+	l := NewHTTPHealthCheck(tlsConfig)
 	_ = l.Init(logger)
 	require.Equal(t, "https", l.Protocol())
 }
 
 func TestHTTPHealthCheckInit(t *testing.T) {
-	l := NewHTTPHealthCheck("healthcheck", testAddr, nil)
+	l := NewHTTPHealthCheck(basicConfig)
 	err := l.Init(logger)
 	require.NoError(t, err)
 
 	require.NotNil(t, l.listen)
-	require.Equal(t, testAddr, l.listen.Addr)
+	require.Equal(t, basicConfig.Address, l.listen.Addr)
 }
 
 func TestHTTPHealthCheckServeAndClose(t *testing.T) {
 	// setup http stats listener
-	l := NewHTTPHealthCheck("healthcheck", testAddr, nil)
+	l := NewHTTPHealthCheck(basicConfig)
 	err := l.Init(logger)
 	require.NoError(t, err)
 
@@ -90,7 +87,7 @@ func TestHTTPHealthCheckServeAndClose(t *testing.T) {
 
 func TestHTTPHealthCheckServeAndCloseMethodNotAllowed(t *testing.T) {
 	// setup http stats listener
-	l := NewHTTPHealthCheck("healthcheck", testAddr, nil)
+	l := NewHTTPHealthCheck(basicConfig)
 	err := l.Init(logger)
 	require.NoError(t, err)
 
@@ -125,10 +122,7 @@ func TestHTTPHealthCheckServeAndCloseMethodNotAllowed(t *testing.T) {
 }
 
 func TestHTTPHealthCheckServeTLSAndClose(t *testing.T) {
-	l := NewHTTPHealthCheck("healthcheck", testAddr, &Config{
-		TLSConfig: tlsConfigBasic,
-	})
-
+	l := NewHTTPHealthCheck(tlsConfig)
 	err := l.Init(logger)
 	require.NoError(t, err)
 

--- a/listeners/http_sysinfo.go
+++ b/listeners/http_sysinfo.go
@@ -17,27 +17,26 @@ import (
 	"github.com/mochi-mqtt/server/v2/system"
 )
 
+const TypeSysInfo = "sysinfo"
+
 // HTTPStats is a listener for presenting the server $SYS stats on a JSON http endpoint.
 type HTTPStats struct {
 	sync.RWMutex
 	id      string       // the internal id of the listener
 	address string       // the network address to bind to
-	config  *Config      // configuration values for the listener
+	config  Config       // configuration values for the listener
 	listen  *http.Server // the http server
 	sysInfo *system.Info // pointers to the server data
 	log     *slog.Logger // server logger
 	end     uint32       // ensure the close methods are only called once
 }
 
-// NewHTTPStats initialises and returns a new HTTP listener, listening on an address.
-func NewHTTPStats(id, address string, config *Config, sysInfo *system.Info) *HTTPStats {
-	if config == nil {
-		config = new(Config)
-	}
+// NewHTTPStats initializes and returns a new HTTP listener, listening on an address.
+func NewHTTPStats(config Config, sysInfo *system.Info) *HTTPStats {
 	return &HTTPStats{
-		id:      id,
-		address: address,
 		sysInfo: sysInfo,
+		id:      config.ID,
+		address: config.Address,
 		config:  config,
 	}
 }

--- a/listeners/http_sysinfo_test.go
+++ b/listeners/http_sysinfo_test.go
@@ -17,38 +17,35 @@ import (
 )
 
 func TestNewHTTPStats(t *testing.T) {
-	l := NewHTTPStats("t1", testAddr, nil, nil)
+	l := NewHTTPStats(basicConfig, nil)
 	require.Equal(t, "t1", l.id)
 	require.Equal(t, testAddr, l.address)
 }
 
 func TestHTTPStatsID(t *testing.T) {
-	l := NewHTTPStats("t1", testAddr, nil, nil)
+	l := NewHTTPStats(basicConfig, nil)
 	require.Equal(t, "t1", l.ID())
 }
 
 func TestHTTPStatsAddress(t *testing.T) {
-	l := NewHTTPStats("t1", testAddr, nil, nil)
+	l := NewHTTPStats(basicConfig, nil)
 	require.Equal(t, testAddr, l.Address())
 }
 
 func TestHTTPStatsProtocol(t *testing.T) {
-	l := NewHTTPStats("t1", testAddr, nil, nil)
+	l := NewHTTPStats(basicConfig, nil)
 	require.Equal(t, "http", l.Protocol())
 }
 
 func TestHTTPStatsTLSProtocol(t *testing.T) {
-	l := NewHTTPStats("t1", testAddr, &Config{
-		TLSConfig: tlsConfigBasic,
-	}, nil)
-
+	l := NewHTTPStats(tlsConfig, nil)
 	_ = l.Init(logger)
 	require.Equal(t, "https", l.Protocol())
 }
 
 func TestHTTPStatsInit(t *testing.T) {
 	sysInfo := new(system.Info)
-	l := NewHTTPStats("t1", testAddr, nil, sysInfo)
+	l := NewHTTPStats(basicConfig, sysInfo)
 	err := l.Init(logger)
 	require.NoError(t, err)
 
@@ -64,7 +61,7 @@ func TestHTTPStatsServeAndClose(t *testing.T) {
 	}
 
 	// setup http stats listener
-	l := NewHTTPStats("t1", testAddr, nil, sysInfo)
+	l := NewHTTPStats(basicConfig, sysInfo)
 	err := l.Init(logger)
 	require.NoError(t, err)
 
@@ -109,9 +106,7 @@ func TestHTTPStatsServeTLSAndClose(t *testing.T) {
 		Version: "test",
 	}
 
-	l := NewHTTPStats("t1", testAddr, &Config{
-		TLSConfig: tlsConfigBasic,
-	}, sysInfo)
+	l := NewHTTPStats(tlsConfig, sysInfo)
 
 	err := l.Init(logger)
 	require.NoError(t, err)
@@ -132,7 +127,9 @@ func TestHTTPStatsFailedToServe(t *testing.T) {
 	}
 
 	// setup http stats listener
-	l := NewHTTPStats("t1", "wrong_addr", nil, sysInfo)
+	config := basicConfig
+	config.Address = "wrong_addr"
+	l := NewHTTPStats(config, sysInfo)
 	err := l.Init(logger)
 	require.NoError(t, err)
 

--- a/listeners/listeners.go
+++ b/listeners/listeners.go
@@ -14,8 +14,10 @@ import (
 
 // Config contains configuration values for a listener.
 type Config struct {
-	// TLSConfig is a tls.Config configuration to be used with the listener.
-	// See examples folder for basic and mutual-tls use.
+	Type    string
+	ID      string
+	Address string
+	// TLSConfig is a tls.Config configuration to be used with the listener. See examples folder for basic and mutual-tls use.
 	TLSConfig *tls.Config
 }
 

--- a/listeners/listeners_test.go
+++ b/listeners/listeners_test.go
@@ -19,6 +19,9 @@ import (
 const testAddr = ":22222"
 
 var (
+	basicConfig = Config{ID: "t1", Address: testAddr}
+	tlsConfig   = Config{ID: "t1", Address: testAddr, TLSConfig: tlsConfigBasic}
+
 	logger = slog.New(slog.NewTextHandler(os.Stdout, nil))
 
 	testCertificate = []byte(`-----BEGIN CERTIFICATE-----
@@ -65,6 +68,7 @@ func init() {
 		MinVersion:   tls.VersionTLS12,
 		Certificates: []tls.Certificate{cert},
 	}
+	tlsConfig.TLSConfig = tlsConfigBasic
 }
 
 func TestNew(t *testing.T) {

--- a/listeners/mock.go
+++ b/listeners/mock.go
@@ -12,6 +12,8 @@ import (
 	"log/slog"
 )
 
+const TypeMock = "mock"
+
 // MockEstablisher is a function signature which can be used in testing.
 func MockEstablisher(id string, c net.Conn) error {
 	return nil

--- a/listeners/tcp.go
+++ b/listeners/tcp.go
@@ -13,26 +13,24 @@ import (
 	"log/slog"
 )
 
+const TypeTCP = "tcp"
+
 // TCP is a listener for establishing client connections on basic TCP protocol.
 type TCP struct { // [MQTT-4.2.0-1]
 	sync.RWMutex
 	id      string       // the internal id of the listener
 	address string       // the network address to bind to
 	listen  net.Listener // a net.Listener which will listen for new clients
-	config  *Config      // configuration values for the listener
+	config  Config       // configuration values for the listener
 	log     *slog.Logger // server logger
 	end     uint32       // ensure the close methods are only called once
 }
 
-// NewTCP initialises and returns a new TCP listener, listening on an address.
-func NewTCP(id, address string, config *Config) *TCP {
-	if config == nil {
-		config = new(Config)
-	}
-
+// NewTCP initializes and returns a new TCP listener, listening on an address.
+func NewTCP(config Config) *TCP {
 	return &TCP{
-		id:      id,
-		address: address,
+		id:      config.ID,
+		address: config.Address,
 		config:  config,
 	}
 }

--- a/listeners/tcp_test.go
+++ b/listeners/tcp_test.go
@@ -14,45 +14,40 @@ import (
 )
 
 func TestNewTCP(t *testing.T) {
-	l := NewTCP("t1", testAddr, nil)
+	l := NewTCP(basicConfig)
 	require.Equal(t, "t1", l.id)
 	require.Equal(t, testAddr, l.address)
 }
 
 func TestTCPID(t *testing.T) {
-	l := NewTCP("t1", testAddr, nil)
+	l := NewTCP(basicConfig)
 	require.Equal(t, "t1", l.ID())
 }
 
 func TestTCPAddress(t *testing.T) {
-	l := NewTCP("t1", testAddr, nil)
+	l := NewTCP(basicConfig)
 	require.Equal(t, testAddr, l.Address())
 }
 
 func TestTCPProtocol(t *testing.T) {
-	l := NewTCP("t1", testAddr, nil)
+	l := NewTCP(basicConfig)
 	require.Equal(t, "tcp", l.Protocol())
 }
 
 func TestTCPProtocolTLS(t *testing.T) {
-	l := NewTCP("t1", testAddr, &Config{
-		TLSConfig: tlsConfigBasic,
-	})
-
+	l := NewTCP(tlsConfig)
 	_ = l.Init(logger)
 	defer l.listen.Close()
 	require.Equal(t, "tcp", l.Protocol())
 }
 
 func TestTCPInit(t *testing.T) {
-	l := NewTCP("t1", testAddr, nil)
+	l := NewTCP(basicConfig)
 	err := l.Init(logger)
 	l.Close(MockCloser)
 	require.NoError(t, err)
 
-	l2 := NewTCP("t2", testAddr, &Config{
-		TLSConfig: tlsConfigBasic,
-	})
+	l2 := NewTCP(tlsConfig)
 	err = l2.Init(logger)
 	l2.Close(MockCloser)
 	require.NoError(t, err)
@@ -60,7 +55,7 @@ func TestTCPInit(t *testing.T) {
 }
 
 func TestTCPServeAndClose(t *testing.T) {
-	l := NewTCP("t1", testAddr, nil)
+	l := NewTCP(basicConfig)
 	err := l.Init(logger)
 	require.NoError(t, err)
 
@@ -85,9 +80,7 @@ func TestTCPServeAndClose(t *testing.T) {
 }
 
 func TestTCPServeTLSAndClose(t *testing.T) {
-	l := NewTCP("t1", testAddr, &Config{
-		TLSConfig: tlsConfigBasic,
-	})
+	l := NewTCP(tlsConfig)
 	err := l.Init(logger)
 	require.NoError(t, err)
 
@@ -109,7 +102,7 @@ func TestTCPServeTLSAndClose(t *testing.T) {
 }
 
 func TestTCPEstablishThenEnd(t *testing.T) {
-	l := NewTCP("t1", testAddr, nil)
+	l := NewTCP(basicConfig)
 	err := l.Init(logger)
 	require.NoError(t, err)
 

--- a/listeners/unixsock.go
+++ b/listeners/unixsock.go
@@ -13,21 +13,25 @@ import (
 	"log/slog"
 )
 
+const TypeUnix = "unix"
+
 // UnixSock is a listener for establishing client connections on basic UnixSock protocol.
 type UnixSock struct {
 	sync.RWMutex
 	id      string       // the internal id of the listener.
 	address string       // the network address to bind to.
+	config  Config       // configuration values for the listener
 	listen  net.Listener // a net.Listener which will listen for new clients.
 	log     *slog.Logger // server logger
 	end     uint32       // ensure the close methods are only called once.
 }
 
-// NewUnixSock initialises and returns a new UnixSock listener, listening on an address.
-func NewUnixSock(id, address string) *UnixSock {
+// NewUnixSock initializes and returns a new UnixSock listener, listening on an address.
+func NewUnixSock(config Config) *UnixSock {
 	return &UnixSock{
-		id:      id,
-		address: address,
+		id:      config.ID,
+		address: config.Address,
+		config:  config,
 	}
 }
 

--- a/listeners/unixsock_test.go
+++ b/listeners/unixsock_test.go
@@ -15,41 +15,47 @@ import (
 
 const testUnixAddr = "mochi.sock"
 
+var (
+	unixConfig = Config{ID: "t1", Address: testUnixAddr}
+)
+
 func TestNewUnixSock(t *testing.T) {
-	l := NewUnixSock("t1", testUnixAddr)
+	l := NewUnixSock(unixConfig)
 	require.Equal(t, "t1", l.id)
 	require.Equal(t, testUnixAddr, l.address)
 }
 
 func TestUnixSockID(t *testing.T) {
-	l := NewUnixSock("t1", testUnixAddr)
+	l := NewUnixSock(unixConfig)
 	require.Equal(t, "t1", l.ID())
 }
 
 func TestUnixSockAddress(t *testing.T) {
-	l := NewUnixSock("t1", testUnixAddr)
+	l := NewUnixSock(unixConfig)
 	require.Equal(t, testUnixAddr, l.Address())
 }
 
 func TestUnixSockProtocol(t *testing.T) {
-	l := NewUnixSock("t1", testUnixAddr)
+	l := NewUnixSock(unixConfig)
 	require.Equal(t, "unix", l.Protocol())
 }
 
 func TestUnixSockInit(t *testing.T) {
-	l := NewUnixSock("t1", testUnixAddr)
+	l := NewUnixSock(unixConfig)
 	err := l.Init(logger)
 	l.Close(MockCloser)
 	require.NoError(t, err)
 
-	l2 := NewUnixSock("t2", testUnixAddr)
+	t2Config := unixConfig
+	t2Config.ID = "t2"
+	l2 := NewUnixSock(t2Config)
 	err = l2.Init(logger)
 	l2.Close(MockCloser)
 	require.NoError(t, err)
 }
 
 func TestUnixSockServeAndClose(t *testing.T) {
-	l := NewUnixSock("t1", testUnixAddr)
+	l := NewUnixSock(unixConfig)
 	err := l.Init(logger)
 	require.NoError(t, err)
 
@@ -74,7 +80,7 @@ func TestUnixSockServeAndClose(t *testing.T) {
 }
 
 func TestUnixSockEstablishThenEnd(t *testing.T) {
-	l := NewUnixSock("t1", testUnixAddr)
+	l := NewUnixSock(unixConfig)
 	err := l.Init(logger)
 	require.NoError(t, err)
 

--- a/listeners/websocket.go
+++ b/listeners/websocket.go
@@ -19,6 +19,8 @@ import (
 	"github.com/gorilla/websocket"
 )
 
+const TypeWS = "ws"
+
 var (
 	// ErrInvalidMessage indicates that a message payload was not valid.
 	ErrInvalidMessage = errors.New("message type not binary")
@@ -29,7 +31,7 @@ type Websocket struct { // [MQTT-4.2.0-1]
 	sync.RWMutex
 	id        string              // the internal id of the listener
 	address   string              // the network address to bind to
-	config    *Config             // configuration values for the listener
+	config    Config              // configuration values for the listener
 	listen    *http.Server        // a http server for serving websocket connections
 	log       *slog.Logger        // server logger
 	establish EstablishFn         // the server's establish connection handler
@@ -37,15 +39,11 @@ type Websocket struct { // [MQTT-4.2.0-1]
 	end       uint32              // ensure the close methods are only called once
 }
 
-// NewWebsocket initialises and returns a new Websocket listener, listening on an address.
-func NewWebsocket(id, address string, config *Config) *Websocket {
-	if config == nil {
-		config = new(Config)
-	}
-
+// NewWebsocket initializes and returns a new Websocket listener, listening on an address.
+func NewWebsocket(config Config) *Websocket {
 	return &Websocket{
-		id:      id,
-		address: address,
+		id:      config.ID,
+		address: config.Address,
 		config:  config,
 		upgrader: &websocket.Upgrader{
 			Subprotocols: []string{"mqtt"},

--- a/listeners/websocket_test.go
+++ b/listeners/websocket_test.go
@@ -17,35 +17,33 @@ import (
 )
 
 func TestNewWebsocket(t *testing.T) {
-	l := NewWebsocket("t1", testAddr, nil)
+	l := NewWebsocket(basicConfig)
 	require.Equal(t, "t1", l.id)
 	require.Equal(t, testAddr, l.address)
 }
 
 func TestWebsocketID(t *testing.T) {
-	l := NewWebsocket("t1", testAddr, nil)
+	l := NewWebsocket(basicConfig)
 	require.Equal(t, "t1", l.ID())
 }
 
 func TestWebsocketAddress(t *testing.T) {
-	l := NewWebsocket("t1", testAddr, nil)
+	l := NewWebsocket(basicConfig)
 	require.Equal(t, testAddr, l.Address())
 }
 
 func TestWebsocketProtocol(t *testing.T) {
-	l := NewWebsocket("t1", testAddr, nil)
+	l := NewWebsocket(basicConfig)
 	require.Equal(t, "ws", l.Protocol())
 }
 
 func TestWebsocketProtocolTLS(t *testing.T) {
-	l := NewWebsocket("t1", testAddr, &Config{
-		TLSConfig: tlsConfigBasic,
-	})
+	l := NewWebsocket(tlsConfig)
 	require.Equal(t, "wss", l.Protocol())
 }
 
 func TestWebsocketInit(t *testing.T) {
-	l := NewWebsocket("t1", testAddr, nil)
+	l := NewWebsocket(basicConfig)
 	require.Nil(t, l.listen)
 	err := l.Init(logger)
 	require.NoError(t, err)
@@ -53,7 +51,7 @@ func TestWebsocketInit(t *testing.T) {
 }
 
 func TestWebsocketServeAndClose(t *testing.T) {
-	l := NewWebsocket("t1", testAddr, nil)
+	l := NewWebsocket(basicConfig)
 	_ = l.Init(logger)
 
 	o := make(chan bool)
@@ -74,9 +72,7 @@ func TestWebsocketServeAndClose(t *testing.T) {
 }
 
 func TestWebsocketServeTLSAndClose(t *testing.T) {
-	l := NewWebsocket("t1", testAddr, &Config{
-		TLSConfig: tlsConfigBasic,
-	})
+	l := NewWebsocket(tlsConfig)
 	err := l.Init(logger)
 	require.NoError(t, err)
 
@@ -96,9 +92,9 @@ func TestWebsocketServeTLSAndClose(t *testing.T) {
 }
 
 func TestWebsocketFailedToServe(t *testing.T) {
-	l := NewWebsocket("t1", "wrong_addr", &Config{
-		TLSConfig: tlsConfigBasic,
-	})
+	config := tlsConfig
+	config.Address = "wrong_addr"
+	l := NewWebsocket(config)
 	err := l.Init(logger)
 	require.NoError(t, err)
 
@@ -117,7 +113,7 @@ func TestWebsocketFailedToServe(t *testing.T) {
 }
 
 func TestWebsocketUpgrade(t *testing.T) {
-	l := NewWebsocket("t1", testAddr, nil)
+	l := NewWebsocket(basicConfig)
 	_ = l.Init(logger)
 
 	e := make(chan bool)
@@ -136,7 +132,7 @@ func TestWebsocketUpgrade(t *testing.T) {
 }
 
 func TestWebsocketConnectionReads(t *testing.T) {
-	l := NewWebsocket("t1", testAddr, nil)
+	l := NewWebsocket(basicConfig)
 	_ = l.Init(nil)
 
 	recv := make(chan []byte)

--- a/server.go
+++ b/server.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	Version                       = "2.4.4" // the current server version.
+	Version                       = "2.5.0" // the current server version.
 	defaultSysTopicInterval int64 = 1       // the interval between $SYS topic publishes
 	LocalListener                 = "local"
 	InlineClientId                = "inline"
@@ -85,8 +85,11 @@ type Compatibilities struct {
 
 // Options contains configurable options for the server.
 type Options struct {
+	// Listeners specifies any listeners which should be dynamically added on serve. Used when setting listeners by config.
 	Listeners []listeners.Config `yaml:"listeners" json:"listeners"`
-	Hooks     []HookLoadConfig   `yaml:"hooks" json:"hooks"`
+
+	// Hooks specifies any hooks which should be dynamically added on serve. Used when setting hooks by config.
+	Hooks []HookLoadConfig `yaml:"hooks" json:"hooks"`
 
 	// Capabilities defines the server features and behaviour. If you only wish to modify
 	// several of these values, set them explicitly - e.g.
@@ -255,6 +258,8 @@ func (s *Server) AddHook(hook Hook, config any) error {
 	return s.hooks.Add(hook, config)
 }
 
+// AddHooksFromConfig adds hooks to the server which were specified in the hooks config (usually from a config file).
+// New built-in hooks should be added to this list.
 func (s *Server) AddHooksFromConfig(hooks []HookLoadConfig) error {
 	for _, h := range hooks {
 		if err := s.AddHook(h.Hook, h.Config); err != nil {
@@ -282,6 +287,8 @@ func (s *Server) AddListener(l listeners.Listener) error {
 	return nil
 }
 
+// AddListenersFromConfig adds listeners to the server which were specified in the listeners config (usually from a config file).
+// New built-in listeners should be added to this list.
 func (s *Server) AddListenersFromConfig(configs []listeners.Config) error {
 	for _, conf := range configs {
 		var l listeners.Listener

--- a/server.go
+++ b/server.go
@@ -71,7 +71,7 @@ func NewDefaultServerCapabilities() *Capabilities {
 		MaximumPacketSize:            0,              // no maximum packet size
 		maximumPacketID:              math.MaxUint16,
 		ReceiveMaximum:               1024,           // maximum number of concurrent qos messages per client
-    MaximumInflight:              1024 * 8,       // maximum number of qos > 0 messages can be stored
+		MaximumInflight:              1024 * 8,       // maximum number of qos > 0 messages can be stored
 		TopicAliasMaximum:            math.MaxUint16, // maximum topic alias value
 		SharedSubAvailable:           1,              // shared subscriptions are available
 		MinimumProtocolVersion:       3,              // minimum supported mqtt version (3.0.0)

--- a/server.go
+++ b/server.go
@@ -45,21 +45,21 @@ var (
 
 // Capabilities indicates the capabilities and features provided by the server.
 type Capabilities struct {
-	MaximumMessageExpiryInterval int64           `yaml:"maximum_message_expiry_interval" json:"maximum_message_expiry_interval"`
-	MaximumClientWritesPending   int32           `yaml:"maximum_client_writes_pending" json:"maximum_client_writes_pending"`
-	MaximumSessionExpiryInterval uint32          `yaml:"maximum_session_expiry_interval" json:"maximum_session_expiry_interval"`
-	MaximumPacketSize            uint32          `yaml:"maximum_packet_size" json:"maximum_packet_size"`
+	MaximumMessageExpiryInterval int64           `yaml:"maximum_message_expiry_interval" json:"maximum_message_expiry_interval"` // maximum message expiry if message expiry is 0 or over
+	MaximumClientWritesPending   int32           `yaml:"maximum_client_writes_pending" json:"maximum_client_writes_pending"`     // maximum number of pending message writes for a client
+	MaximumSessionExpiryInterval uint32          `yaml:"maximum_session_expiry_interval" json:"maximum_session_expiry_interval"` // maximum number of seconds to keep disconnected sessions
+	MaximumPacketSize            uint32          `yaml:"maximum_packet_size" json:"maximum_packet_size"`                         // maximum packet size, no limit if 0
 	maximumPacketID              uint32          // unexported, used for testing only
-	ReceiveMaximum               uint16          `yaml:"receive_maximum" json:"receive_maximum"`
-	MaximumInflight              uint16   		`yaml:"maximum_inflight" json:"maximum_inflight"` // maximum number of qos > 0 messages can be stored, 0(=8192)-65535
-	TopicAliasMaximum            uint16          `yaml:"topic_alias_maximum" json:"topic_alias_maximum"`
-	SharedSubAvailable           byte            `yaml:"shared_sub_available" json:"shared_sub_available"`
-	MinimumProtocolVersion       byte            `yaml:"minimum_protocol_version" json:"minimum_protocol_version"`
-	Compatibilities              Compatibilities `yaml:"compatibilities" json:"compatibilities"`
-	MaximumQos                   byte            `yaml:"maximum_qos" json:"maximum_qos"`
-	RetainAvailable              byte            `yaml:"retain_available" json:"retain_available"`
-	WildcardSubAvailable         byte            `yaml:"wildcard_sub_available" json:"wildcard_sub_available"`
-	SubIDAvailable               byte            `yaml:"sub_id_available" json:"sub_id_available"`
+	ReceiveMaximum               uint16          `yaml:"receive_maximum" json:"receive_maximum"`                   // maximum number of concurrent qos messages per client
+	MaximumInflight              uint16          `yaml:"maximum_inflight" json:"maximum_inflight"`                 // maximum number of qos > 0 messages can be stored, 0(=8192)-65535
+	TopicAliasMaximum            uint16          `yaml:"topic_alias_maximum" json:"topic_alias_maximum"`           // maximum topic alias value
+	SharedSubAvailable           byte            `yaml:"shared_sub_available" json:"shared_sub_available"`         // support of shared subscriptions
+	MinimumProtocolVersion       byte            `yaml:"minimum_protocol_version" json:"minimum_protocol_version"` // minimum supported mqtt version
+	Compatibilities              Compatibilities `yaml:"compatibilities" json:"compatibilities"`                   // version compatibilities the server provides
+	MaximumQos                   byte            `yaml:"maximum_qos" json:"maximum_qos"`                           // maximum qos value available to clients
+	RetainAvailable              byte            `yaml:"retain_available" json:"retain_available"`                 // support of retain messages
+	WildcardSubAvailable         byte            `yaml:"wildcard_sub_available" json:"wildcard_sub_available"`     // support of wildcard subscriptions
+	SubIDAvailable               byte            `yaml:"sub_id_available" json:"sub_id_available"`                 // support of subscription identifiers
 }
 
 // NewDefaultServerCapabilities defines the default features and capabilities provided by the server.
@@ -80,6 +80,7 @@ func NewDefaultServerCapabilities() *Capabilities {
 		WildcardSubAvailable:         1,              // wildcard subscriptions are available
 		SubIDAvailable:               1,              // subscription identifiers are available
 	}
+
 }
 
 // Compatibilities provides flags for using compatibility modes.

--- a/server.go
+++ b/server.go
@@ -1419,27 +1419,28 @@ func (s *Server) publishSysTopics() {
 	atomic.StoreInt64(&s.Info.ClientsTotal, int64(s.Clients.Len()))
 	atomic.StoreInt64(&s.Info.ClientsDisconnected, atomic.LoadInt64(&s.Info.ClientsTotal)-atomic.LoadInt64(&s.Info.ClientsConnected))
 
+	info := s.Info.Clone()
 	topics := map[string]string{
 		SysPrefix + "/broker/version":              s.Info.Version,
-		SysPrefix + "/broker/time":                 AtomicItoa(&s.Info.Time),
-		SysPrefix + "/broker/uptime":               AtomicItoa(&s.Info.Uptime),
-		SysPrefix + "/broker/started":              AtomicItoa(&s.Info.Started),
-		SysPrefix + "/broker/load/bytes/received":  AtomicItoa(&s.Info.BytesReceived),
-		SysPrefix + "/broker/load/bytes/sent":      AtomicItoa(&s.Info.BytesSent),
-		SysPrefix + "/broker/clients/connected":    AtomicItoa(&s.Info.ClientsConnected),
-		SysPrefix + "/broker/clients/disconnected": AtomicItoa(&s.Info.ClientsDisconnected),
-		SysPrefix + "/broker/clients/maximum":      AtomicItoa(&s.Info.ClientsMaximum),
-		SysPrefix + "/broker/clients/total":        AtomicItoa(&s.Info.ClientsTotal),
-		SysPrefix + "/broker/packets/received":     AtomicItoa(&s.Info.PacketsReceived),
-		SysPrefix + "/broker/packets/sent":         AtomicItoa(&s.Info.PacketsSent),
-		SysPrefix + "/broker/messages/received":    AtomicItoa(&s.Info.MessagesReceived),
-		SysPrefix + "/broker/messages/sent":        AtomicItoa(&s.Info.MessagesSent),
-		SysPrefix + "/broker/messages/dropped":     AtomicItoa(&s.Info.MessagesDropped),
-		SysPrefix + "/broker/messages/inflight":    AtomicItoa(&s.Info.Inflight),
-		SysPrefix + "/broker/retained":             AtomicItoa(&s.Info.Retained),
-		SysPrefix + "/broker/subscriptions":        AtomicItoa(&s.Info.Subscriptions),
-		SysPrefix + "/broker/system/memory":        AtomicItoa(&s.Info.MemoryAlloc),
-		SysPrefix + "/broker/system/threads":       AtomicItoa(&s.Info.Threads),
+		SysPrefix + "/broker/time":                 Int64toa(info.Time),
+		SysPrefix + "/broker/uptime":               Int64toa(info.Uptime),
+		SysPrefix + "/broker/started":              Int64toa(info.Started),
+		SysPrefix + "/broker/load/bytes/received":  Int64toa(info.BytesReceived),
+		SysPrefix + "/broker/load/bytes/sent":      Int64toa(info.BytesSent),
+		SysPrefix + "/broker/clients/connected":    Int64toa(info.ClientsConnected),
+		SysPrefix + "/broker/clients/disconnected": Int64toa(info.ClientsDisconnected),
+		SysPrefix + "/broker/clients/maximum":      Int64toa(info.ClientsMaximum),
+		SysPrefix + "/broker/clients/total":        Int64toa(info.ClientsTotal),
+		SysPrefix + "/broker/packets/received":     Int64toa(info.PacketsReceived),
+		SysPrefix + "/broker/packets/sent":         Int64toa(info.PacketsSent),
+		SysPrefix + "/broker/messages/received":    Int64toa(info.MessagesReceived),
+		SysPrefix + "/broker/messages/sent":        Int64toa(info.MessagesSent),
+		SysPrefix + "/broker/messages/dropped":     Int64toa(info.MessagesDropped),
+		SysPrefix + "/broker/messages/inflight":    Int64toa(info.Inflight),
+		SysPrefix + "/broker/retained":             Int64toa(info.Retained),
+		SysPrefix + "/broker/subscriptions":        Int64toa(info.Subscriptions),
+		SysPrefix + "/broker/system/memory":        Int64toa(info.MemoryAlloc),
+		SysPrefix + "/broker/system/threads":       Int64toa(info.Threads),
 	}
 
 	for topic, payload := range topics {
@@ -1449,7 +1450,7 @@ func (s *Server) publishSysTopics() {
 		s.publishToSubscribers(pk)
 	}
 
-	s.hooks.OnSysInfoTick(s.Info)
+	s.hooks.OnSysInfoTick(info)
 }
 
 // Close attempts to gracefully shut down the server, all listeners, clients, and stores.
@@ -1718,7 +1719,7 @@ func (s *Server) sendDelayedLWT(dt int64) {
 	}
 }
 
-// AtomicItoa converts an int64 point to a string.
-func AtomicItoa(ptr *int64) string {
-	return strconv.FormatInt(atomic.LoadInt64(ptr), 10)
+// Int64toa converts an int64 to a string.
+func Int64toa(v int64) string {
+	return strconv.FormatInt(v, 10)
 }

--- a/server.go
+++ b/server.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	Version                       = "2.5.0" // the current server version.
+	Version                       = "2.6.0" // the current server version.
 	defaultSysTopicInterval int64 = 1       // the interval between $SYS topic publishes
 	LocalListener                 = "local"
 	InlineClientId                = "inline"

--- a/server.go
+++ b/server.go
@@ -14,6 +14,7 @@ import (
 	"runtime"
 	"sort"
 	"strconv"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -52,65 +53,69 @@ var (
 	ErrListenerIDExists       = errors.New("listener id already exists")                               // a listener with the same id already exists
 	ErrConnectionClosed       = errors.New("connection not open")                                      // connection is closed
 	ErrInlineClientNotEnabled = errors.New("please set Options.InlineClient=true to use this feature") // inline client is not enabled by default
+	ErrOptionsUnreadable      = errors.New("unable to read options from bytes")
 )
 
 // Capabilities indicates the capabilities and features provided by the server.
 type Capabilities struct {
-	MaximumMessageExpiryInterval int64
-	MaximumClientWritesPending   int32
-	MaximumSessionExpiryInterval uint32
-	MaximumPacketSize            uint32
-	maximumPacketID              uint32 // unexported, used for testing only
-	ReceiveMaximum               uint16
-	TopicAliasMaximum            uint16
-	SharedSubAvailable           byte
-	MinimumProtocolVersion       byte
-	Compatibilities              Compatibilities
-	MaximumQos                   byte
-	RetainAvailable              byte
-	WildcardSubAvailable         byte
-	SubIDAvailable               byte
+	MaximumMessageExpiryInterval int64           `yaml:"maximum_message_expiry_interval" json:"maximum_message_expiry_interval"`
+	MaximumClientWritesPending   int32           `yaml:"maximum_client_writes_pending" json:"maximum_client_writes_pending"`
+	MaximumSessionExpiryInterval uint32          `yaml:"maximum_session_expiry_interval" json:"maximum_session_expiry_interval"`
+	MaximumPacketSize            uint32          `yaml:"maximum_packet_size" json:"maximum_packet_size"`
+	maximumPacketID              uint32          // unexported, used for testing only
+	ReceiveMaximum               uint16          `yaml:"receive_maximum" json:"receive_maximum"`
+	TopicAliasMaximum            uint16          `yaml:"topic_alias_maximum" json:"topic_alias_maximum"`
+	SharedSubAvailable           byte            `yaml:"shared_sub_available" json:"shared_sub_available"`
+	MinimumProtocolVersion       byte            `yaml:"minimum_protocol_version" json:"minimum_protocol_version"`
+	Compatibilities              Compatibilities `yaml:"compatibilities" json:"compatibilities"`
+	MaximumQos                   byte            `yaml:"maximum_qos" json:"maximum_qos"`
+	RetainAvailable              byte            `yaml:"retain_available" json:"retain_available"`
+	WildcardSubAvailable         byte            `yaml:"wildcard_sub_available" json:"wildcard_sub_available"`
+	SubIDAvailable               byte            `yaml:"sub_id_available" json:"sub_id_available"`
 }
 
 // Compatibilities provides flags for using compatibility modes.
 type Compatibilities struct {
-	ObscureNotAuthorized       bool // return unspecified errors instead of not authorized
-	PassiveClientDisconnect    bool // don't disconnect the client forcefully after sending disconnect packet (paho - spec violation)
-	AlwaysReturnResponseInfo   bool // always return response info (useful for testing)
-	RestoreSysInfoOnRestart    bool // restore system info from store as if server never stopped
-	NoInheritedPropertiesOnAck bool // don't allow inherited user properties on ack (paho - spec violation)
+	ObscureNotAuthorized       bool `yaml:"obscure_not_authorized" json:"obscure_not_authorized"`                 // return unspecified errors instead of not authorized
+	PassiveClientDisconnect    bool `yaml:"passive_client_disconnect" json:"passive_client_disconnect"`           // don't disconnect the client forcefully after sending disconnect packet (paho - spec violation)
+	AlwaysReturnResponseInfo   bool `yaml:"always_return_response_info" json:"always_return_response_info"`       // always return response info (useful for testing)
+	RestoreSysInfoOnRestart    bool `yaml:"restore_sys_info_on_restart" json:"restore_sys_info_on_restart"`       // restore system info from store as if server never stopped
+	NoInheritedPropertiesOnAck bool `yaml:"no_inherited_properties_on_ack" json:"no_inherited_properties_on_ack"` // don't allow inherited user properties on ack (paho - spec violation)
 }
 
 // Options contains configurable options for the server.
 type Options struct {
+	Listeners []listeners.Config `yaml:"listeners" json:"listeners"`
+	Hooks     []HookLoadConfig   `yaml:"hooks" json:"hooks"`
+
 	// Capabilities defines the server features and behaviour. If you only wish to modify
 	// several of these values, set them explicitly - e.g.
 	// 	server.Options.Capabilities.MaximumClientWritesPending = 16 * 1024
-	Capabilities *Capabilities
+	Capabilities *Capabilities `yaml:"capabilities" json:"capabilities"`
 
 	// ClientNetWriteBufferSize specifies the size of the client *bufio.Writer write buffer.
-	ClientNetWriteBufferSize int
+	ClientNetWriteBufferSize int `yaml:"client_net_write_buffer_size" json:"client_net_write_buffer_size"`
 
 	// ClientNetReadBufferSize specifies the size of the client *bufio.Reader read buffer.
-	ClientNetReadBufferSize int
+	ClientNetReadBufferSize int `yaml:"client_net_read_buffer_size" json:"client_net_read_buffer_size"`
 
 	// Logger specifies a custom configured implementation of zerolog to override
 	// the servers default logger configuration. If you wish to change the log level,
-	// of the default logger, you can do so by setting
-	// 	server := mqtt.New(nil)
+	// of the default logger, you can do so by setting:
+	// server := mqtt.New(nil)
 	// level := new(slog.LevelVar)
 	// server.Slog = slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
 	// 	Level: level,
 	// }))
 	// level.Set(slog.LevelDebug)
-	Logger *slog.Logger
+	Logger *slog.Logger `yaml:"-" json:"-"`
 
 	// SysTopicResendInterval specifies the interval between $SYS topic updates in seconds.
-	SysTopicResendInterval int64
+	SysTopicResendInterval int64 `yaml:"sys_topic_resend_interval" json:"sys_topic_resend_interval"`
 
 	// Enable Inline client to allow direct subscribing and publishing from the parent codebase,
 	// with negligible performance difference (disabled by default to prevent confusion in statistics).
-	InlineClient bool
+	InlineClient bool `yaml:"inline_client" json:"inline_client"`
 }
 
 // Server is an MQTT broker server. It should be created with server.New()
@@ -250,6 +255,15 @@ func (s *Server) AddHook(hook Hook, config any) error {
 	return s.hooks.Add(hook, config)
 }
 
+func (s *Server) AddHooksFromConfig(hooks []HookLoadConfig) error {
+	for _, h := range hooks {
+		if err := s.AddHook(h.Hook, h.Config); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // AddListener adds a new network listener to the server, for receiving incoming client connections.
 func (s *Server) AddListener(l listeners.Listener) error {
 	if _, ok := s.Listeners.Get(l.ID()); ok {
@@ -268,11 +282,52 @@ func (s *Server) AddListener(l listeners.Listener) error {
 	return nil
 }
 
+func (s *Server) AddListenersFromConfig(configs []listeners.Config) error {
+	for _, conf := range configs {
+		var l listeners.Listener
+		switch strings.ToLower(conf.Type) {
+		case listeners.TypeTCP:
+			l = listeners.NewTCP(conf)
+		case listeners.TypeWS:
+			l = listeners.NewWebsocket(conf)
+		case listeners.TypeUnix:
+			l = listeners.NewUnixSock(conf)
+		case listeners.TypeHealthCheck:
+			l = listeners.NewHTTPHealthCheck(conf)
+		case listeners.TypeSysInfo:
+			l = listeners.NewHTTPStats(conf, s.Info)
+		case listeners.TypeMock:
+			l = listeners.NewMockListener(conf.ID, conf.Address)
+		default:
+			s.Log.Error("listener type unavailable by config", "listener", conf.Type)
+			continue
+		}
+		if err := s.AddListener(l); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // Serve starts the event loops responsible for establishing client connections
 // on all attached listeners, publishing the system topics, and starting all hooks.
 func (s *Server) Serve() error {
 	s.Log.Info("mochi mqtt starting", "version", Version)
 	defer s.Log.Info("mochi mqtt server started")
+
+	if len(s.Options.Listeners) > 0 {
+		err := s.AddListenersFromConfig(s.Options.Listeners)
+		if err != nil {
+			return err
+		}
+	}
+
+	if len(s.Options.Hooks) > 0 {
+		err := s.AddHooksFromConfig(s.Options.Hooks)
+		if err != nil {
+			return err
+		}
+	}
 
 	if s.hooks.Provides(
 		StoredClients,

--- a/server.go
+++ b/server.go
@@ -34,21 +34,8 @@ const (
 )
 
 var (
-	// DefaultServerCapabilities defines the default features and capabilities provided by the server.
-	DefaultServerCapabilities = &Capabilities{
-		MaximumSessionExpiryInterval: math.MaxUint32, // maximum number of seconds to keep disconnected sessions
-		MaximumMessageExpiryInterval: 60 * 60 * 24,   // maximum message expiry if message expiry is 0 or over
-		ReceiveMaximum:               1024,           // maximum number of concurrent qos messages per client
-		MaximumQos:                   2,              // maximum qos value available to clients
-		RetainAvailable:              1,              // retain messages is available
-		MaximumPacketSize:            0,              // no maximum packet size
-		TopicAliasMaximum:            math.MaxUint16, // maximum topic alias value
-		WildcardSubAvailable:         1,              // wildcard subscriptions are available
-		SubIDAvailable:               1,              // subscription identifiers are available
-		SharedSubAvailable:           1,              // shared subscriptions are available
-		MinimumProtocolVersion:       3,              // minimum supported mqtt version (3.0.0)
-		MaximumClientWritesPending:   1024 * 8,       // maximum number of pending message writes for a client
-	}
+	// Deprecated: Use NewDefaultServerCapabilities to avoid data race issue.
+	DefaultServerCapabilities = NewDefaultServerCapabilities()
 
 	ErrListenerIDExists       = errors.New("listener id already exists")                               // a listener with the same id already exists
 	ErrConnectionClosed       = errors.New("connection not open")                                      // connection is closed
@@ -72,6 +59,25 @@ type Capabilities struct {
 	RetainAvailable              byte            `yaml:"retain_available" json:"retain_available"`
 	WildcardSubAvailable         byte            `yaml:"wildcard_sub_available" json:"wildcard_sub_available"`
 	SubIDAvailable               byte            `yaml:"sub_id_available" json:"sub_id_available"`
+}
+
+// NewDefaultServerCapabilities defines the default features and capabilities provided by the server.
+func NewDefaultServerCapabilities() *Capabilities {
+	return &Capabilities{
+		MaximumMessageExpiryInterval: 60 * 60 * 24,   // maximum message expiry if message expiry is 0 or over
+		MaximumClientWritesPending:   1024 * 8,       // maximum number of pending message writes for a client
+		MaximumSessionExpiryInterval: math.MaxUint32, // maximum number of seconds to keep disconnected sessions
+		MaximumPacketSize:            0,              // no maximum packet size
+		maximumPacketID:              math.MaxUint16,
+		ReceiveMaximum:               1024,           // maximum number of concurrent qos messages per client
+		TopicAliasMaximum:            math.MaxUint16, // maximum topic alias value
+		SharedSubAvailable:           1,              // shared subscriptions are available
+		MinimumProtocolVersion:       3,              // minimum supported mqtt version (3.0.0)
+		MaximumQos:                   2,              // maximum qos value available to clients
+		RetainAvailable:              1,              // retain messages is available
+		WildcardSubAvailable:         1,              // wildcard subscriptions are available
+		SubIDAvailable:               1,              // subscription identifiers are available
+	}
 }
 
 // Compatibilities provides flags for using compatibility modes.
@@ -198,7 +204,7 @@ func New(opts *Options) *Server {
 // ensureDefaults ensures that the server starts with sane default values, if none are provided.
 func (o *Options) ensureDefaults() {
 	if o.Capabilities == nil {
-		o.Capabilities = DefaultServerCapabilities
+		o.Capabilities = NewDefaultServerCapabilities()
 	}
 
 	o.Capabilities.maximumPacketID = math.MaxUint16 // spec maximum is 65535

--- a/server_test.go
+++ b/server_test.go
@@ -96,24 +96,24 @@ func (h *DelayHook) OnDisconnect(cl *Client, err error, expire bool) {
 }
 
 func newServer() *Server {
-	cc := *DefaultServerCapabilities
+	cc := NewDefaultServerCapabilities()
 	cc.MaximumMessageExpiryInterval = 0
 	cc.ReceiveMaximum = 0
 	s := New(&Options{
 		Logger:       logger,
-		Capabilities: &cc,
+		Capabilities: cc,
 	})
 	_ = s.AddHook(new(AllowHook), nil)
 	return s
 }
 
 func newServerWithInlineClient() *Server {
-	cc := *DefaultServerCapabilities
+	cc := NewDefaultServerCapabilities()
 	cc.MaximumMessageExpiryInterval = 0
 	cc.ReceiveMaximum = 0
 	s := New(&Options{
 		Logger:       logger,
-		Capabilities: &cc,
+		Capabilities: cc,
 		InlineClient: true,
 	})
 	_ = s.AddHook(new(AllowHook), nil)
@@ -125,7 +125,7 @@ func TestOptionsSetDefaults(t *testing.T) {
 	opts.ensureDefaults()
 
 	require.Equal(t, defaultSysTopicInterval, opts.SysTopicResendInterval)
-	require.Equal(t, DefaultServerCapabilities, opts.Capabilities)
+	require.Equal(t, NewDefaultServerCapabilities(), opts.Capabilities)
 
 	opts = new(Options)
 	opts.ensureDefaults()
@@ -1662,10 +1662,10 @@ func TestServerProcessPublishACLCheckDeny(t *testing.T) {
 
 	for _, tx := range tt {
 		t.Run(tx.name, func(t *testing.T) {
-			cc := *DefaultServerCapabilities
+			cc := NewDefaultServerCapabilities()
 			s := New(&Options{
 				Logger:       logger,
-				Capabilities: &cc,
+				Capabilities: cc,
 			})
 			_ = s.AddHook(new(DenyHook), nil)
 			_ = s.Serve()

--- a/server_test.go
+++ b/server_test.go
@@ -3521,10 +3521,9 @@ func TestLoadServerInfoRestoreOnRestart(t *testing.T) {
 	require.Equal(t, int64(60), s.Info.BytesReceived)
 }
 
-func TestAtomicItoa(t *testing.T) {
+func TestItoa(t *testing.T) {
 	i := int64(22)
-	ip := &i
-	require.Equal(t, "22", AtomicItoa(ip))
+	require.Equal(t, "22", Int64toa(i))
 }
 
 func TestServerSubscribe(t *testing.T) {


### PR DESCRIPTION
Following our discussions and @dgduncan's work in #309, here is a PR which implements a new file-based configuration for the broker. 

A runnable example can be found in `examples/config`.

**How it works**
Rather creating a layer which adds listeners and hooks as they are in the main.go files, I have opted instead to update the hooks and listeners so that they can be applied directly through the server options.

The server options, capabilities, and compatibilities transfer directly from yaml/json into their normal options struct, as though it were being provided as a value created in main.go. Refer to `examples/config/config.yaml` (or `config.json`) for all options.
 
The listeners are defined using a slice Listener.Config, specifying the Type, ID, and Address. TLS can also be specified although I haven't tried it, so it may need a bit of work.

Hooks are defined individually, and split by category. As above, see config.yaml for a full list of options for each hook. This was a bit tricky to implement in a respectable manner, but in the end I decided to simply give hooks their own configuration struct, and allow only one type of each hook, which allows us to provide custom parameters for each (e.g. Auth and Storage.Redis).

I have updated the Dockerfile and added a `cmd/docker.main.go` as per @dgduncan's original work. I have not tested it.

**Caveats**
- If you use file-based configuration, you can only have one of each hook type. However, this should be fine for 99% of users.
- You can only use built in hooks with file-based configuration, as the type needs to be known in order for it to be applied.
- You can only use built in listeners, for the reasons above.

Contains breaking changes for the way listeners are initialized (id and address are now in Config).

If you wish to use custom hooks and listeners, you will currently need to modify the code to support these, or just use the standard system of applying them in a custom go file.

I suspect I've missed some edge-cases too, but thought I'd submit it for review :) 