### PR TITLE
Fix #349, MQTT v3 unsuback does not require Reason Code.

### DIFF
--- a/packets/packets.go
+++ b/packets/packets.go
@@ -1009,9 +1009,8 @@ func (pk *Packet) UnsubackEncode(buf *bytes.Buffer) error {
 		defer mempool.PutBuffer(pb)
 		pk.Properties.Encode(pk.FixedHeader.Type, pk.Mods, pb, nb.Len())
 		nb.Write(pb.Bytes())
+		nb.Write(pk.ReasonCodes)
 	}
-
-	nb.Write(pk.ReasonCodes)
 
 	pk.FixedHeader.Remaining = nb.Len()
 	pk.FixedHeader.Encode(buf)


### PR DESCRIPTION
According to MQTT v3 spec [3.11 UNSUBACK – Unsubscribe acknowledgement](https://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718077), MQTT v3 UNSUBACK does not require a Reason Code.