### PR TITLE
Fix #352 message does not save at session when client is disconnect.

### DIFF
--- a/server.go
+++ b/server.go
@@ -500,10 +500,11 @@ func (s *Server) inheritClientSession(pk packets.Packet, cl *Client) bool {
 			}
 			cl.State.Subscriptions.Add(sub.Filter, sub)
 		}
-
+	
 		// Clean the state of the existing client to prevent sequential take-overs
 		// from increasing memory usage by inflights + subs * client-id.
-		if !s.Options.Capabilities.Compatibilities.TakeoverSubInheritable {
+		uninheritable := !s.Options.Capabilities.Compatibilities.TakeoverSubInheritable
+		if uninheritable {
 			s.UnsubscribeClient(existing)
 		}
 		existing.ClearInflights()


### PR DESCRIPTION
For #352, According to MQTT spec [3.1.2.4 Clean Session](https://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718030) , if the client does not expire, we should retain the client's subscriptions upon reconnection. However, I tested Mosquitto, and it does not support this feature. Therefore, I think making this an optional capability is a good idea.  You can enable this capability by coding as follows:

```go
capabilities := mqtt.DefaultServerCapabilities
capabilities.Compatibilities.TakeoverSubInheritable = true

server := mqtt.New(&mqtt.Options{
	InlineClient: true,
	Capabilities: capabilities,
})
```