### PR TITLE
Buffer optimizations

### DIFF
--- a/clients.go
+++ b/clients.go
@@ -598,6 +598,9 @@ func (cl *Client) WritePacket(pk packets.Packet) error {
 
 		// there are more writes in the queue
 		if cl.Net.outbuf == nil {
+			if buf.Len() >= cl.ops.options.ClientNetWriteBufferSize {
+				return buf.WriteTo(cl.Net.Conn)
+			}
 			cl.Net.outbuf = new(bytes.Buffer)
 		}
 

--- a/packets/packets.go
+++ b/packets/packets.go
@@ -348,7 +348,7 @@ func (pk *Packet) ConnectEncode(buf *bytes.Buffer) error {
 
 	pk.FixedHeader.Remaining = nb.Len()
 	pk.FixedHeader.Encode(buf)
-	_, _ = nb.WriteTo(buf)
+	buf.Write(nb.Bytes())
 
 	return nil
 }
@@ -512,7 +512,8 @@ func (pk *Packet) ConnackEncode(buf *bytes.Buffer) error {
 
 	pk.FixedHeader.Remaining = nb.Len()
 	pk.FixedHeader.Encode(buf)
-	_, _ = nb.WriteTo(buf)
+	buf.Write(nb.Bytes())
+
 	return nil
 }
 
@@ -557,7 +558,7 @@ func (pk *Packet) DisconnectEncode(buf *bytes.Buffer) error {
 
 	pk.FixedHeader.Remaining = nb.Len()
 	pk.FixedHeader.Encode(buf)
-	_, _ = nb.WriteTo(buf)
+	buf.Write(nb.Bytes())
 
 	return nil
 }
@@ -628,7 +629,7 @@ func (pk *Packet) PublishEncode(buf *bytes.Buffer) error {
 
 	pk.FixedHeader.Remaining = nb.Len() + len(pk.Payload)
 	pk.FixedHeader.Encode(buf)
-	_, _ = nb.WriteTo(buf)
+	buf.Write(nb.Bytes())
 	buf.Write(pk.Payload)
 
 	return nil
@@ -719,7 +720,7 @@ func (pk *Packet) encodePubAckRelRecComp(buf *bytes.Buffer) error {
 
 	pk.FixedHeader.Remaining = nb.Len()
 	pk.FixedHeader.Encode(buf)
-	_, _ = nb.WriteTo(buf)
+	buf.Write(nb.Bytes())
 	return nil
 }
 
@@ -858,7 +859,7 @@ func (pk *Packet) SubackEncode(buf *bytes.Buffer) error {
 
 	pk.FixedHeader.Remaining = nb.Len()
 	pk.FixedHeader.Encode(buf)
-	_, _ = nb.WriteTo(buf)
+	buf.Write(nb.Bytes())
 
 	return nil
 }
@@ -918,7 +919,7 @@ func (pk *Packet) SubscribeEncode(buf *bytes.Buffer) error {
 
 	pk.FixedHeader.Remaining = nb.Len()
 	pk.FixedHeader.Encode(buf)
-	_, _ = nb.WriteTo(buf)
+	buf.Write(nb.Bytes())
 
 	return nil
 }
@@ -1015,7 +1016,7 @@ func (pk *Packet) UnsubackEncode(buf *bytes.Buffer) error {
 
 	pk.FixedHeader.Remaining = nb.Len()
 	pk.FixedHeader.Encode(buf)
-	_, _ = nb.WriteTo(buf)
+	buf.Write(nb.Bytes())
 
 	return nil
 }
@@ -1071,7 +1072,7 @@ func (pk *Packet) UnsubscribeEncode(buf *bytes.Buffer) error {
 
 	pk.FixedHeader.Remaining = nb.Len()
 	pk.FixedHeader.Encode(buf)
-	_, _ = nb.WriteTo(buf)
+	buf.Write(nb.Bytes())
 
 	return nil
 }
@@ -1133,7 +1134,7 @@ func (pk *Packet) AuthEncode(buf *bytes.Buffer) error {
 
 	pk.FixedHeader.Remaining = nb.Len()
 	pk.FixedHeader.Encode(buf)
-	_, _ = nb.WriteTo(buf)
+	buf.Write(nb.Bytes())
 	return nil
 }
 

--- a/packets/properties.go
+++ b/packets/properties.go
@@ -359,7 +359,7 @@ func (p *Properties) Encode(pkt byte, mods Mods, b *bytes.Buffer, n int) {
 	}
 
 	encodeLength(b, int64(buf.Len()))
-	_, _ = buf.WriteTo(b) // [MQTT-3.1.3-10]
+	b.Write(buf.Bytes()) // [MQTT-3.1.3-10]
 }
 
 // Decode decodes property bytes into a properties struct.

--- a/packets/properties.go
+++ b/packets/properties.go
@@ -8,6 +8,8 @@ import (
 	"bytes"
 	"fmt"
 	"strings"
+
+	"github.com/mochi-mqtt/server/v2/mempool"
 )
 
 const (
@@ -199,7 +201,8 @@ func (p *Properties) Encode(pkt byte, mods Mods, b *bytes.Buffer, n int) {
 		return
 	}
 
-	var buf bytes.Buffer
+	buf := mempool.GetBuffer()
+	defer mempool.PutBuffer(buf)
 	if p.canEncode(pkt, PropPayloadFormat) && p.PayloadFormatFlag {
 		buf.WriteByte(PropPayloadFormat)
 		buf.WriteByte(p.PayloadFormat)
@@ -230,7 +233,7 @@ func (p *Properties) Encode(pkt byte, mods Mods, b *bytes.Buffer, n int) {
 		for _, v := range p.SubscriptionIdentifier {
 			if v > 0 {
 				buf.WriteByte(PropSubscriptionIdentifier)
-				encodeLength(&buf, int64(v))
+				encodeLength(buf, int64(v))
 			}
 		}
 	}
@@ -321,7 +324,8 @@ func (p *Properties) Encode(pkt byte, mods Mods, b *bytes.Buffer, n int) {
 	}
 
 	if !mods.DisallowProblemInfo && p.canEncode(pkt, PropUser) {
-		pb := bytes.NewBuffer([]byte{})
+		pb := mempool.GetBuffer()
+		defer mempool.PutBuffer(pb)
 		for _, v := range p.User {
 			pb.WriteByte(PropUser)
 			pb.Write(encodeString(v.Key))


### PR DESCRIPTION
Few buffer optimizations:
1. Avoid creating/writing to outbound buffer if outbound was nil and pkt is larger than ClientNetWriteBufferSize
2. Use mempool for Properties Encode as well
3. Use the more efficient Write instead of WriteTo for Buffer to Buffer writes (as it won't be partially successful)

Benchmark comparing Write vs WriteTo (the performance difference is reverse proportion to the packet size, using 128 bytes for benchmark as vast majority packets without payload should be less than that):
```go
func BenchmarkWrite(b *testing.B) {
	const PacketSize = 128
	d := make([]byte, PacketSize)
	if _, err := rand.Read(d); err != nil {
		panic(err)
	}
	dst := new(bytes.Buffer)

	b.ResetTimer()
	b.ReportAllocs()
	for i := 0; i < b.N; i++ {
		src := bytes.NewBuffer(d)
		dst.Write(src.Bytes())
		dst.Reset()
	}
}

func BenchmarkWriteTo(b *testing.B) {
	const PacketSize = 128
	d := make([]byte, PacketSize)
	if _, err := rand.Read(d); err != nil {
		panic(err)
	}
	dst := new(bytes.Buffer)

	b.ResetTimer()
	b.ReportAllocs()

	for i := 0; i < b.N; i++ {
		src := bytes.NewBuffer(d)
		src.WriteTo(dst)
		dst.Reset()
	}
}
```

```
cpu: Intel(R) Core(TM) i7-7920HQ CPU @ 3.10GHz
BenchmarkWrite-8     	163843377	         7.306 ns/op	       0 B/op	       0 allocs/op
BenchmarkWriteTo-8   	100000000	        12.15 ns/op	       0 B/op	       0 allocs/op
```