### PR TITLE
Add BadgerDB garbage collection.

### DIFF
--- a/examples/persistence/badger/main.go
+++ b/examples/persistence/badger/main.go
@@ -11,10 +11,12 @@ import (
 	"syscall"
 	"time"
 
+	badgerdb "github.com/dgraph-io/badger"
 	mqtt "github.com/mochi-mqtt/server/v2"
 	"github.com/mochi-mqtt/server/v2/hooks/auth"
 	"github.com/mochi-mqtt/server/v2/hooks/storage/badger"
 	"github.com/mochi-mqtt/server/v2/listeners"
+	"github.com/timshannon/badgerhold"
 )
 
 func main() {
@@ -36,8 +38,16 @@ func main() {
 	// GcInterval specifies the interval at which BadgerDB garbage collection process runs.
 	// Refer to https://dgraph.io/docs/badger/get-started/#garbage-collection for more information.
 	err := server.AddHook(new(badger.Hook), &badger.Options{
-		Path: badgerPath,
+		Path:       badgerPath,
 		GcInterval: 3 * time.Minute, // Set the interval for garbage collection.
+		Options: &badgerhold.Options{
+			// BadgerDB options. Modify as needed.
+			Options: badgerdb.Options{
+				NumCompactors:    2,               // Number of compactors. Compactions can be expensive.
+				MaxTableSize:     64 << 20,        // Maximum size of each table (64 MB).
+				ValueLogFileSize: 100 * (1 << 20), // Set the default size of the log file to 100 MB.
+			},
+		},
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/examples/persistence/badger/main.go
+++ b/examples/persistence/badger/main.go
@@ -39,9 +39,19 @@ func main() {
 	// Refer to https://dgraph.io/docs/badger/get-started/#garbage-collection for more information.
 	err := server.AddHook(new(badger.Hook), &badger.Options{
 		Path:       badgerPath,
-		GcInterval: 3 * time.Minute, // Set the interval for garbage collection.
+
+		// Set the interval for garbage collection. Adjust according to your actual scenario.
+		GcInterval: 5 * time.Minute, 
+
+		// GcDiscardRatio specifies the ratio of log discard compared to the maximum possible log discard.
+		// Setting it to a higher value would result in fewer space reclaims, while setting it to a lower value
+		// would result in more space reclaims at the cost of increased activity on the LSM tree.
+		// discardRatio must be in the range (0.0, 1.0), both endpoints excluded, otherwise, it will be set to the default value of 0.5.
+		// Adjust according to your actual scenario.
+		GcDiscardRatio: 0.5,
+
 		Options: &badgerhold.Options{
-			// BadgerDB options. Modify as needed.
+			// BadgerDB options. Adjust according to your actual scenario.
 			Options: badgerdb.Options{
 				NumCompactors:    2,               // Number of compactors. Compactions can be expensive.
 				MaxTableSize:     64 << 20,        // Maximum size of each table (64 MB).

--- a/examples/persistence/badger/main.go
+++ b/examples/persistence/badger/main.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	mqtt "github.com/mochi-mqtt/server/v2"
 	"github.com/mochi-mqtt/server/v2/hooks/auth"
@@ -31,8 +32,12 @@ func main() {
 	server := mqtt.New(nil)
 	_ = server.AddHook(new(auth.AllowHook), nil)
 
+	// AddHook adds a BadgerDB hook to the server with the specified options.
+	// GcInterval specifies the interval at which BadgerDB garbage collection process runs.
+	// Refer to https://dgraph.io/docs/badger/get-started/#garbage-collection for more information.
 	err := server.AddHook(new(badger.Hook), &badger.Options{
 		Path: badgerPath,
+		GcInterval: 3 * time.Minute, // Set the interval for garbage collection.
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/hooks/storage/badger/badger.go
+++ b/hooks/storage/badger/badger.go
@@ -22,6 +22,7 @@ import (
 const (
 	// defaultDbFile is the default file path for the badger db file.
 	defaultDbFile = ".badger"
+	defaultGcInterval = 5 * time.Minute
 )
 
 // clientKey returns a primary key for a client.
@@ -121,6 +122,10 @@ func (h *Hook) Init(config any) error {
 	h.config = config.(*Options)
 	if h.config.Path == "" {
 		h.config.Path = defaultDbFile
+	}
+
+	if h.config.GcInterval == 0 {
+		h.config.GcInterval = defaultGcInterval
 	}
 
 	options := badgerhold.DefaultOptions

--- a/hooks/storage/badger/badger.go
+++ b/hooks/storage/badger/badger.go
@@ -131,8 +131,6 @@ func (h *Hook) Init(config any) error {
 	options.Dir = h.config.Path
 	options.ValueDir = h.config.Path
 	options.Logger = h
-	// Set the default size of the log file to 100 MB. Modify as needed.
-	options.ValueLogFileSize = 100 * (1 << 20)
 
 	var err error
 	h.db, err = badgerhold.Open(options)

--- a/hooks/storage/badger/badger.go
+++ b/hooks/storage/badger/badger.go
@@ -97,7 +97,6 @@ func (h *Hook) Provides(b byte) bool {
 // It uses a ticker to trigger the garbage collection at regular intervals specified by the configuration.
 // Refer to: https://dgraph.io/docs/badger/get-started/#garbage-collection
 func (h *Hook) GcLoop() {
-	h.gcTicker = time.NewTicker(h.config.GcInterval)
 	for range h.gcTicker.C {
 	again:
 		// Run the garbage collection process with a threshold of 0.7.
@@ -140,6 +139,8 @@ func (h *Hook) Init(config any) error {
 	if err != nil {
 		return err
 	}
+
+	h.gcTicker = time.NewTicker(h.config.GcInterval)
 	go h.GcLoop()
 
 	return nil

--- a/hooks/storage/badger/badger_test.go
+++ b/hooks/storage/badger/badger_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	badgerdb "github.com/dgraph-io/badger"
 	mqtt "github.com/mochi-mqtt/server/v2"
 	"github.com/mochi-mqtt/server/v2/hooks/storage"
 	"github.com/mochi-mqtt/server/v2/packets"
@@ -701,4 +702,22 @@ func TestDebugf(t *testing.T) {
 	h := new(Hook)
 	h.SetOpts(logger, nil)
 	h.Debugf("test", 1, 2, 3)
+}
+
+func TestGcLoop(t *testing.T) {
+	h := new(Hook)
+	h.SetOpts(logger, nil)
+	h.Init(&Options{
+		GcInterval: 10 * time.Second, // Set the interval for garbage collection.
+		Options: &badgerhold.Options{
+			// BadgerDB options. Modify as needed.
+			Options: badgerdb.Options{
+				ValueLogFileSize: 1 << 20, // Set the default size of the log file to 1 MB.
+			},
+		},
+	})
+	defer teardown(t, h.config.Path, h)
+	h.OnSessionEstablished(client, packets.Packet{})
+	h.OnDisconnect(client, nil, true)
+	time.Sleep(20 * time.Second)
 }

--- a/hooks/storage/badger/badger_test.go
+++ b/hooks/storage/badger/badger_test.go
@@ -708,7 +708,7 @@ func TestGcLoop(t *testing.T) {
 	h := new(Hook)
 	h.SetOpts(logger, nil)
 	h.Init(&Options{
-		GcInterval: 10 * time.Second, // Set the interval for garbage collection.
+		GcInterval: 2 * time.Second, // Set the interval for garbage collection.
 		Options: &badgerhold.Options{
 			// BadgerDB options. Modify as needed.
 			Options: badgerdb.Options{
@@ -719,5 +719,5 @@ func TestGcLoop(t *testing.T) {
 	defer teardown(t, h.config.Path, h)
 	h.OnSessionEstablished(client, packets.Packet{})
 	h.OnDisconnect(client, nil, true)
-	time.Sleep(20 * time.Second)
+	time.Sleep(3 * time.Second)
 }


### PR DESCRIPTION
For issues #370, #369, and #363. I've tested it myself under the condition of setting the log file size to 1MB. With 1000 clients repeatedly connecting and disconnecting with the same client ID, if GC is not enabled, the log file continues to grow indefinitely. Enabling the GC loop resolves this issue.