### PR TITLE
Add logging level file config

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -5,6 +5,8 @@
 package config
 
 import (
+	"log/slog"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -60,7 +62,6 @@ options:
    }
 }
 `)
-
 	parsedOptions = mqtt.Options{
 		Listeners: []listeners.Config{
 			{
@@ -81,6 +82,9 @@ options:
 				RestoreSysInfoOnRestart: true,
 			},
 		},
+		Logger: slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+			Level: new(slog.LevelVar),
+		})),
 	}
 )
 

--- a/examples/config/config.yaml
+++ b/examples/config/config.yaml
@@ -65,3 +65,5 @@ options:
       always_return_response_info: false
       restore_sys_info_on_restart: false
       no_inherited_properties_on_ack: false
+logging:
+  level: INFO

--- a/server.go
+++ b/server.go
@@ -112,7 +112,7 @@ type Options struct {
 	// ClientNetReadBufferSize specifies the size of the client *bufio.Reader read buffer.
 	ClientNetReadBufferSize int `yaml:"client_net_read_buffer_size" json:"client_net_read_buffer_size"`
 
-	// Logger specifies a custom configured implementation of zerolog to override
+	// Logger specifies a custom configured implementation of log/slog to override
 	// the servers default logger configuration. If you wish to change the log level,
 	// of the default logger, you can do so by setting:
 	// server := mqtt.New(nil)

--- a/server_test.go
+++ b/server_test.go
@@ -2258,7 +2258,7 @@ func TestPublishToSubscribersExhaustedSendQuota(t *testing.T) {
 	require.True(t, subbed)
 
 	// coverage: subscriber publish errors are non-returnable
-	// can we hook into zerolog ?
+	// can we hook into log/slog ?
 	_ = r.Close()
 	pkx := *packets.TPacketData[packets.Publish].Get(packets.TPublishQos1).Packet
 	pkx.PacketID = 0
@@ -2279,7 +2279,7 @@ func TestPublishToSubscribersExhaustedPacketIDs(t *testing.T) {
 	require.True(t, subbed)
 
 	// coverage: subscriber publish errors are non-returnable
-	// can we hook into zerolog ?
+	// can we hook into log/slog ?
 	_ = r.Close()
 	pkx := *packets.TPacketData[packets.Publish].Get(packets.TPublishQos1).Packet
 	pkx.PacketID = 0
@@ -2296,7 +2296,7 @@ func TestPublishToSubscribersNoConnection(t *testing.T) {
 	require.True(t, subbed)
 
 	// coverage: subscriber publish errors are non-returnable
-	// can we hook into zerolog ?
+	// can we hook into log/slog ?
 	_ = r.Close()
 	s.publishToSubscribers(*packets.TPacketData[packets.Publish].Get(packets.TPublishBasic).Packet)
 	time.Sleep(time.Millisecond)


### PR DESCRIPTION
Adds the ability to configure logging level from the file based config. It does this by creating a logger with a `Levelvar` during file based configuration and parsing the included. If no `logging` options are configured, `INFO` is assumed. 