### PR TITLE
Added client.StopTime(), to expose `disconnected`

### DIFF
--- a/clients.go
+++ b/clients.go
@@ -417,6 +417,11 @@ func (cl *Client) StopCause() error {
 	return cl.State.stopCause.Load().(error)
 }
 
+// StopTime returns the the time the client disconnected in unix time, else zero.
+func (cl *Client) StopTime() int64 {
+	return atomic.LoadInt64(&cl.State.disconnected)
+}
+
 // Closed returns true if client connection is closed.
 func (cl *Client) Closed() bool {
 	return cl.State.open == nil || cl.State.open.Err() != nil

--- a/clients_test.go
+++ b/clients_test.go
@@ -583,9 +583,11 @@ func TestClientReadDone(t *testing.T) {
 
 func TestClientStop(t *testing.T) {
 	cl, _, _ := newTestClient()
+	require.Equal(t, int64(0), cl.StopTime())
 	cl.Stop(nil)
 	require.Equal(t, nil, cl.State.stopCause.Load())
-	require.Equal(t, time.Now().Unix(), cl.State.disconnected)
+	require.InDelta(t, time.Now().Unix(), cl.State.disconnected, 1.0)
+	require.Equal(t, cl.State.disconnected, cl.StopTime())
 	require.True(t, cl.Closed())
 	require.Equal(t, nil, cl.StopCause())
 }

--- a/server.go
+++ b/server.go
@@ -1689,7 +1689,7 @@ func (s *Server) loadRetained(v []storage.Message) {
 // than their given expiry intervals.
 func (s *Server) clearExpiredClients(dt int64) {
 	for id, client := range s.Clients.GetAll() {
-		disconnected := atomic.LoadInt64(&client.State.disconnected)
+		disconnected := client.StopTime()
 		if disconnected == 0 {
 			continue
 		}


### PR DESCRIPTION
My persistence hook needs to know what time a client disconnected. The field `Client.State.disconnected` has that information but it's not exposed in the API, so I added a simple public accessor method `Client.StopTime()`.