### PR TITLE
Allow a Hook to reload an individual client session

### DIFF
--- a/hooks.go
+++ b/hooks.go
@@ -55,6 +55,7 @@ const (
 	StoredInflightMessages
 	StoredRetainedMessages
 	StoredSysInfo
+	StoredClientByID
 )
 
 var (
@@ -114,6 +115,7 @@ type Hook interface {
 	StoredInflightMessages() ([]storage.Message, error)
 	StoredRetainedMessages() ([]storage.Message, error)
 	StoredSysInfo() (storage.SystemInfo, error)
+	StoredClientByID(id string, username []byte) (string, []storage.Subscription, []storage.Message, error)
 }
 
 // HookOptions contains values which are inherited from the server on initialisation.
@@ -679,6 +681,25 @@ func (h *Hooks) OnACLCheck(cl *Client, topic string, write bool) bool {
 	return false
 }
 
+// StoredClientByID returns the state of the stored client with the given session ID, if any.
+func (h *Hooks) StoredClientByID(id string, username []byte) (oldRemote string, subs []storage.Subscription, msgs []storage.Message, err error) {
+	for _, hook := range h.GetAll() {
+		if hook.Provides(StoredClientByID) {
+			oldRemote, subs, msgs, err = hook.StoredClientByID(id, username)
+			if err != nil {
+				h.Log.Error("failed to load client by ID", "error", err, "hook", hook.ID())
+				return
+			}
+
+			if oldRemote != "" && err == nil {
+				return
+			}
+		}
+	}
+
+	return
+}
+
 // HookBase provides a set of default methods for each hook. It should be embedded in
 // all hooks.
 type HookBase struct {
@@ -857,5 +878,10 @@ func (h *HookBase) StoredRetainedMessages() (v []storage.Message, err error) {
 
 // StoredSysInfo returns a set of system info values.
 func (h *HookBase) StoredSysInfo() (v storage.SystemInfo, err error) {
+	return
+}
+
+// StoredClientByID returns the state of the stored client with the given session ID, if any.
+func (h *HookBase) StoredClientByID(id string, username []byte) (oldRemote string, subs []storage.Subscription, msgs []storage.Message, err error) {
 	return
 }


### PR DESCRIPTION
In a clustered environment, client connections are distributed among multiple Server instances on different machines. After a client disconnects, leaving behind a persistent session state, its next login is likely to be on a different node. Because of this, in such a setup an individual Server instance should only keep Client instances corresponding to online client connections, and it should be able to reload an individual client's state (presumably from persistent storage) when that client reconnects.

This commit adds support for such an environment by adding a new hook `StoredClientByID`. An implementation finds and returns any persistent client data for a given session ID. In practice the only necessary information turned out to be the saved subscriptions and in-flight ack messages. The hook also returns the prior 'Remote' property since the server logs that.

The Server method `inheritClientSession` is extended to call this hook if there is no matching in-memory Client session. If the hook returns session data, it installs it into the Client object in the same way as the existing code.

At the end of the Server method `attachClient`, after disconnection, the existence of a `StoredClientByID` hook is checked; if present, the method expires the Client instance so it won't hang around in memory and so the next connection will go to the hook to reload state.