### PR TITLE
use cl.ID instead of pk.Connect.ClientIdentifier when looking for existing clients in inheritClientSession

### DIFF
--- a/server.go
+++ b/server.go
@@ -560,7 +560,7 @@ func (s *Server) validateConnect(cl *Client, pk packets.Packet) packets.Code {
 // connection ID. If clean is true, the state of any previously existing client
 // session is abandoned.
 func (s *Server) inheritClientSession(pk packets.Packet, cl *Client) bool {
-	if existing, ok := s.Clients.Get(pk.Connect.ClientIdentifier); ok {
+	if existing, ok := s.Clients.Get(cl.ID); ok {
 		_ = s.DisconnectClient(existing, packets.ErrSessionTakenOver)                                   // [MQTT-3.1.4-3]
 		if pk.Connect.Clean || (existing.Properties.Clean && existing.Properties.ProtocolVersion < 5) { // [MQTT-3.1.2-4] [MQTT-3.1.4-4]
 			s.UnsubscribeClient(existing)

--- a/server.go
+++ b/server.go
@@ -560,13 +560,7 @@ func (s *Server) validateConnect(cl *Client, pk packets.Packet) packets.Code {
 // connection ID. If clean is true, the state of any previously existing client
 // session is abandoned.
 func (s *Server) inheritClientSession(pk packets.Packet, cl *Client) bool {
-
-	clientID := pk.Connect.ClientIdentifier
-	if cl.Properties.Props.AssignedClientID != "" {
-		clientID = cl.Properties.Props.AssignedClientID
-	}
-
-	if existing, ok := s.Clients.Get(clientID); ok {
+	if existing, ok := s.Clients.Get(cl.ID); ok {
 		_ = s.DisconnectClient(existing, packets.ErrSessionTakenOver)                                   // [MQTT-3.1.4-3]
 		if pk.Connect.Clean || (existing.Properties.Clean && existing.Properties.ProtocolVersion < 5) { // [MQTT-3.1.2-4] [MQTT-3.1.4-4]
 			s.UnsubscribeClient(existing)

--- a/server.go
+++ b/server.go
@@ -560,7 +560,13 @@ func (s *Server) validateConnect(cl *Client, pk packets.Packet) packets.Code {
 // connection ID. If clean is true, the state of any previously existing client
 // session is abandoned.
 func (s *Server) inheritClientSession(pk packets.Packet, cl *Client) bool {
-	if existing, ok := s.Clients.Get(cl.ID); ok {
+
+	clientID := pk.Connect.ClientIdentifier
+	if cl.Properties.Props.AssignedClientID != "" {
+		clientID = cl.Properties.Props.AssignedClientID
+	}
+
+	if existing, ok := s.Clients.Get(clientID); ok {
 		_ = s.DisconnectClient(existing, packets.ErrSessionTakenOver)                                   // [MQTT-3.1.4-3]
 		if pk.Connect.Clean || (existing.Properties.Clean && existing.Properties.ProtocolVersion < 5) { // [MQTT-3.1.2-4] [MQTT-3.1.4-4]
 			s.UnsubscribeClient(existing)


### PR DESCRIPTION
Fix https://github.com/mochi-mqtt/server/issues/416

The reason I want to open this PR:
* cl.ID is set from the `pk.Connect.ClientIdentifier` in [clients.go](https://github.com/mochi-mqtt/server/blob/82c96fa4e3f20259c2d947bb87eb8dc885ef6824/clients.go#L236-L236), It also is the same value as the assignedClientId if there is one. Therefore it is more correct, but also for the reasons below:
* This allows my custom implementation to rely on `cl.ID` and override it and the assigned id returned to the client(I assign intentional, known, client ids to specific clients. We want to control the client ids based on the authenticating client.) 

All tests still pass, including the existing client takeover tests.

@mochi-co  Do you think the existing tests are good for this, or do we want some kind of regression test case? I was looking at the tests to add one but to be honest, it is a bit beyond my Go skill level at the moment. 

