### PR TITLE
Improve message expiry

### DIFF
--- a/clients.go
+++ b/clients.go
@@ -533,7 +533,11 @@ func (cl *Client) WritePacket(pk packets.Packet) error {
 	}
 
 	if pk.Expiry > 0 {
-		pk.Properties.MessageExpiryInterval = uint32(pk.Expiry - time.Now().Unix()) // [MQTT-3.3.2-6]
+		expiry := pk.Expiry - time.Now().Unix()
+		if expiry < 1 {
+			expiry = 1
+		}
+		pk.Properties.MessageExpiryInterval = uint32(expiry) // [MQTT-3.3.2-6]
 	}
 
 	pk.ProtocolVersion = cl.Properties.ProtocolVersion

--- a/server_test.go
+++ b/server_test.go
@@ -3920,3 +3920,14 @@ func TestServerSubscribeWithRetainDifferentIdentifier(t *testing.T) {
 		require.Equal(t, true, <-finishCh)
 	}
 }
+
+func TestMinimum(t *testing.T) {
+	require.EqualValues(t, 0, minimum(0, 0))
+	require.EqualValues(t, 1, minimum(0, 1))
+	require.EqualValues(t, 1, minimum(1, 0))
+	require.EqualValues(t, 10, minimum(10, 20))
+	require.EqualValues(t, 20, minimum(30, 20))
+	require.EqualValues(t, -1, minimum(-1, 0)) // negative values are not used, but included here for completeness
+	require.EqualValues(t, -1, minimum(-1, 20))
+	require.EqualValues(t, -2, minimum(-1, -2))
+}


### PR DESCRIPTION
This includes changes:
1. Address @dariopb's issue in #442 
2. Only set pk.Expiry if pk.Properties.MessageExpiryInterval or MaximumMessageExpiryInterval is not zero-value
3. Ensure outgoing pk.Properties.MessageExpiryInterval doesn't contain uint32(of negative value or zero-value) by setting a minimum of 1