### PR TITLE
Change MaximumClientWritesPending to 64

### DIFF
--- a/server.go
+++ b/server.go
@@ -68,7 +68,7 @@ func NewDefaultServerCapabilities() *Capabilities {
 	return &Capabilities{
 		MaximumClients:               math.MaxInt64,  // maximum number of connected clients
 		MaximumMessageExpiryInterval: 60 * 60 * 24,   // maximum message expiry if message expiry is 0 or over
-		MaximumClientWritesPending:   1024 * 8,       // maximum number of pending message writes for a client
+		MaximumClientWritesPending:   64,             // maximum number of pending message writes for a client
 		MaximumSessionExpiryInterval: math.MaxUint32, // maximum number of seconds to keep disconnected sessions
 		MaximumPacketSize:            0,              // no maximum packet size
 		maximumPacketID:              math.MaxUint16,


### PR DESCRIPTION
Adjust MaximumClientWritesPending default value: from 1024*8 to 64

- Current default value is too high, causing significant memory overhead when maintaining a large number of connections (tens of thousands)
- Testing shows that reducing this value significantly decreases memory usage, optimizing resource utilization

## Technical Impact
- Minimal impact on small-scale deployments
- Significantly improves memory usage in high-concurrency scenarios
- No effect on core functionality and performance
