### PR TITLE
Fix QoS 2 message rejections to send PUBREC instead of PUBACK, allow errRejectPacket through

### DIFF
--- a/server.go
+++ b/server.go
@@ -913,10 +913,10 @@ func (s *Server) processPublish(cl *Client, pk packets.Packet) error {
 	pkx, err := s.hooks.OnPublish(cl, pk)
 	if err == nil {
 		pk = pkx
-	} else if errors.Is(err, packets.ErrRejectPacket) && cl.Properties.ProtocolVersion != 5 {
-		return nil
 	} else if errors.Is(err, packets.CodeSuccessIgnore) {
 		pk.Ignore = true
+	} else if cl.Properties.ProtocolVersion != 5 || pk.FixedHeader.Qos == 0 {
+		return nil
 	} else if cl.Properties.ProtocolVersion == 5 && pk.FixedHeader.Qos > 0 && errors.As(err, new(packets.Code)) {
 		ackType := packets.Puback
 		if pk.FixedHeader.Qos == 2 {

--- a/server.go
+++ b/server.go
@@ -913,6 +913,8 @@ func (s *Server) processPublish(cl *Client, pk packets.Packet) error {
 	pkx, err := s.hooks.OnPublish(cl, pk)
 	if err == nil {
 		pk = pkx
+	} else if errors.Is(err, packets.ErrRejectPacket) && (cl.Properties.ProtocolVersion != 5 || pk.FixedHeader.Qos == 0) {
+		return nil
 	} else if errors.Is(err, packets.CodeSuccessIgnore) {
 		pk.Ignore = true
 	} else if cl.Properties.ProtocolVersion == 5 && pk.FixedHeader.Qos > 0 && errors.As(err, new(packets.Code)) {

--- a/server.go
+++ b/server.go
@@ -916,7 +916,7 @@ func (s *Server) processPublish(cl *Client, pk packets.Packet) error {
 	} else if errors.Is(err, packets.CodeSuccessIgnore) {
 		pk.Ignore = true
 	} else if cl.Properties.ProtocolVersion != 5 || pk.FixedHeader.Qos == 0 {
-		return nil
+		return err
 	} else if cl.Properties.ProtocolVersion == 5 && pk.FixedHeader.Qos > 0 && errors.As(err, new(packets.Code)) {
 		ackType := packets.Puback
 		if pk.FixedHeader.Qos == 2 {
@@ -927,6 +927,8 @@ func (s *Server) processPublish(cl *Client, pk packets.Packet) error {
 			return err
 		}
 		return nil
+	} else {
+		return err
 	}
 
 	if pk.FixedHeader.Retain { // [MQTT-3.3.1-5] ![MQTT-3.3.1-8]

--- a/server.go
+++ b/server.go
@@ -913,7 +913,7 @@ func (s *Server) processPublish(cl *Client, pk packets.Packet) error {
 	pkx, err := s.hooks.OnPublish(cl, pk)
 	if err == nil {
 		pk = pkx
-	} else if errors.Is(err, packets.ErrRejectPacket) && (cl.Properties.ProtocolVersion != 5 || pk.FixedHeader.Qos == 0) {
+	} else if errors.Is(err, packets.ErrRejectPacket) && cl.Properties.ProtocolVersion != 5 {
 		return nil
 	} else if errors.Is(err, packets.CodeSuccessIgnore) {
 		pk.Ignore = true

--- a/server_test.go
+++ b/server_test.go
@@ -1739,7 +1739,8 @@ func TestServerProcessPublishACLCheckDeny(t *testing.T) {
 	}
 }
 
-func TestServerProcessPublishOnMessageRecvRejected(t *testing.T) {
+func TestServerProcessPublishOnMessageRecvRejectedQos0(t *testing.T) {
+	// Test that QoS 0 rejections return the error (not silently ignored)
 	s := newServer()
 	require.NotNil(t, s)
 	hook := new(modifiedHookBase)
@@ -1752,8 +1753,10 @@ func TestServerProcessPublishOnMessageRecvRejected(t *testing.T) {
 	_ = s.Serve()
 	defer s.Close()
 	cl, _, _ := newTestClient()
+	
+	// QoS 0 rejections should return the error for proper handling by caller
 	err = s.processPublish(cl, *packets.TPacketData[packets.Publish].Get(packets.TPublishBasic).Packet)
-	require.NoError(t, err) // packets rejected silently
+	require.ErrorIs(t, err, packets.ErrRejectPacket)
 }
 
 func TestServerProcessPublishOnMessageRecvRejectedQos1(t *testing.T) {

--- a/server_test.go
+++ b/server_test.go
@@ -1740,7 +1740,7 @@ func TestServerProcessPublishACLCheckDeny(t *testing.T) {
 }
 
 func TestServerProcessPublishOnMessageRecvRejectedQos0(t *testing.T) {
-	// Test that QoS 0 rejections return the error (not silently ignored)
+	// Test that QoS 0 rejections are silently ignored (return nil)
 	s := newServer()
 	require.NotNil(t, s)
 	hook := new(modifiedHookBase)
@@ -1754,9 +1754,9 @@ func TestServerProcessPublishOnMessageRecvRejectedQos0(t *testing.T) {
 	defer s.Close()
 	cl, _, _ := newTestClient()
 	
-	// QoS 0 rejections should return the error for proper handling by caller
+	// QoS 0 rejections should be silently ignored (return nil)
 	err = s.processPublish(cl, *packets.TPacketData[packets.Publish].Get(packets.TPublishBasic).Packet)
-	require.ErrorIs(t, err, packets.ErrRejectPacket)
+	require.NoError(t, err)
 }
 
 func TestServerProcessPublishOnMessageRecvRejectedQos1(t *testing.T) {


### PR DESCRIPTION
Fix QoS 2 message rejections to send PUBREC instead of PUBACK and remove the errRejectPacket no-op check.

I am unsure why the line which I removed was there, but that was stopping that packet from falling through to the lower if block where it would have made a puback as needed for qos1. However, for qos2 it should be pubrec so I addressed that here too. 

[Link to spec](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901124)

Fixes https://github.com/mochi-mqtt/server/issues/465