### PR TITLE
Fix potential deadlock in `GetByListener` function

### DIFF
--- a/clients.go
+++ b/clients.go
@@ -92,7 +92,7 @@ func (cl *Clients) Delete(id string) {
 func (cl *Clients) GetByListener(id string) []*Client {
 	cl.RLock()
 	defer cl.RUnlock()
-	clients := make([]*Client, 0, cl.Len())
+	clients := make([]*Client, 0, len(cl.internal))
 	for _, client := range cl.internal {
 		if client.Net.Listener == id && !client.Closed() {
 			clients = append(clients, client)


### PR DESCRIPTION
The deadlock occured when a write lock was requested between the two recursive read locks. The second read lock request blocked, preventing the first read lock from releasing and allowing the write lock, thus creating a deadlock.

This fixes issue #488