### PR TITLE
fix log spam when EOF error on connection close

### DIFF
--- a/listeners/tcp.go
+++ b/listeners/tcp.go
@@ -84,7 +84,7 @@ func (l *TCP) Serve(establish EstablishFn) {
 		if atomic.LoadUint32(&l.end) == 0 {
 			go func() {
 				err = establish(l.id, conn)
-				if err != nil && err != io.EOF {
+				if err != nil && errors.Is(err, io.EOF) {
 					l.log.Warn("", "error", err)
 				}
 			}()

--- a/listeners/tcp.go
+++ b/listeners/tcp.go
@@ -6,6 +6,7 @@ package listeners
 
 import (
 	"crypto/tls"
+	"io"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -83,7 +84,7 @@ func (l *TCP) Serve(establish EstablishFn) {
 		if atomic.LoadUint32(&l.end) == 0 {
 			go func() {
 				err = establish(l.id, conn)
-				if err != nil {
+				if err != nil && err != io.EOF {
 					l.log.Warn("", "error", err)
 				}
 			}()


### PR DESCRIPTION
currently, the TCP listener logs every connection end, even if it's clean with io.EOF. 
