### PR TITLE
fix inflight by mutex

### DIFF
--- a/inflight.go
+++ b/inflight.go
@@ -7,7 +7,6 @@ package mqtt
 import (
 	"sort"
 	"sync"
-	"sync/atomic"
 
 	"github.com/mochi-mqtt/server/v2/packets"
 )
@@ -16,6 +15,7 @@ import (
 type Inflight struct {
 	sync.RWMutex
 	internal            map[uint16]packets.Packet // internal contains the inflight packets
+	quotaMu             sync.Mutex                // protects quota fields
 	receiveQuota        int32                     // remaining inbound qos quota for flow control
 	sendQuota           int32                     // remaining outbound qos quota for flow control
 	maximumReceiveQuota int32                     // maximum allowed receive quota
@@ -115,42 +115,72 @@ func (i *Inflight) Delete(id uint16) bool {
 	return ok
 }
 
-// TakeRecieveQuota reduces the receive quota by 1.
-func (i *Inflight) DecreaseReceiveQuota() {
-	if atomic.LoadInt32(&i.receiveQuota) > 0 {
-		atomic.AddInt32(&i.receiveQuota, -1)
+// DecreaseReceiveQuota reduces the receive quota by 1.
+// Returns true if quota was successfully decreased, false if quota was already 0.
+func (i *Inflight) DecreaseReceiveQuota() bool {
+	i.quotaMu.Lock()
+	defer i.quotaMu.Unlock()
+
+	if i.receiveQuota <= 0 {
+		return false
 	}
+	i.receiveQuota--
+	return true
 }
 
-// TakeRecieveQuota increases the receive quota by 1.
-func (i *Inflight) IncreaseReceiveQuota() {
-	if atomic.LoadInt32(&i.receiveQuota) < atomic.LoadInt32(&i.maximumReceiveQuota) {
-		atomic.AddInt32(&i.receiveQuota, 1)
+// IncreaseReceiveQuota increases the receive quota by 1.
+// Returns true if quota was successfully increased, false if already at maximum.
+func (i *Inflight) IncreaseReceiveQuota() bool {
+	i.quotaMu.Lock()
+	defer i.quotaMu.Unlock()
+
+	if i.receiveQuota >= i.maximumReceiveQuota {
+		return false
 	}
+	i.receiveQuota++
+	return true
 }
 
 // ResetReceiveQuota resets the receive quota to the maximum allowed value.
 func (i *Inflight) ResetReceiveQuota(n int32) {
-	atomic.StoreInt32(&i.receiveQuota, n)
-	atomic.StoreInt32(&i.maximumReceiveQuota, n)
+	i.quotaMu.Lock()
+	defer i.quotaMu.Unlock()
+
+	i.maximumReceiveQuota = n
+	i.receiveQuota = n
 }
 
 // DecreaseSendQuota reduces the send quota by 1.
-func (i *Inflight) DecreaseSendQuota() {
-	if atomic.LoadInt32(&i.sendQuota) > 0 {
-		atomic.AddInt32(&i.sendQuota, -1)
+// Returns true if quota was successfully decreased, false if quota was already 0.
+func (i *Inflight) DecreaseSendQuota() bool {
+	i.quotaMu.Lock()
+	defer i.quotaMu.Unlock()
+
+	if i.sendQuota <= 0 {
+		return false
 	}
+	i.sendQuota--
+	return true
 }
 
 // IncreaseSendQuota increases the send quota by 1.
-func (i *Inflight) IncreaseSendQuota() {
-	if atomic.LoadInt32(&i.sendQuota) < atomic.LoadInt32(&i.maximumSendQuota) {
-		atomic.AddInt32(&i.sendQuota, 1)
+// Returns true if quota was successfully increased, false if already at maximum.
+func (i *Inflight) IncreaseSendQuota() bool {
+	i.quotaMu.Lock()
+	defer i.quotaMu.Unlock()
+
+	if i.sendQuota >= i.maximumSendQuota {
+		return false
 	}
+	i.sendQuota++
+	return true
 }
 
 // ResetSendQuota resets the send quota to the maximum allowed value.
 func (i *Inflight) ResetSendQuota(n int32) {
-	atomic.StoreInt32(&i.sendQuota, n)
-	atomic.StoreInt32(&i.maximumSendQuota, n)
+	i.quotaMu.Lock()
+	defer i.quotaMu.Unlock()
+
+	i.maximumSendQuota = n
+	i.sendQuota = n
 }


### PR DESCRIPTION
Follow your suggestion， Use sync.Mutex fix the struct of inflight .


# 在高并发模式下，windows不会锁死，但是linux服务器上跑会锁死

## 问题代码
```
if atomic.LoadInt32(&i.receiveQuota) > 0 {
    atomic.AddInt32(&i.receiveQuota, -1)
}
````
这段代码存在 TOCTOU（Time-Of-Check-Time-Of-Use）竞态条件：

检查时刻：LoadInt32 读取到值 > 0

使用时刻：执行 AddInt32(-1)

在两个操作之间，其他goroutine可能已经将值减到0或负数

## 为什么Windows下“正常”，Linux下“锁死”？
这涉及到内存模型和编译器/CPU优化的差异：

**1. 内存重排序**

x86/Windows：采用强内存模型（TSO），Load和Store操作有较强的顺序保证

Linux（可能运行在ARM、PowerPC等）：采用弱内存模型，允许更多重排序

**2. 原子操作的可见性**

在高并发场景下：

```
// 假设初始值为 1

// Goroutine A
if atomic.LoadInt32(&quota) > 0 {  // 读到 1
    // 此时可能被调度出去
    // Goroutine B 可能将 quota 减到 0
    atomic.AddInt32(&quota, -1)     // 将 0 减到 -1
}
```

**3.“锁死”的真正含义**

quota 变成负数：由于竞态条件，quota 可能被减到 -1、-2 等

后续操作无法恢复：因为检查条件是 > 0，一旦变成负数，永远无法再获取 quota

死锁现象：资源永远不会被释放或恢复
