### PR TITLE
fix(clients): GetByListener took RLock recursively and could deadlock

### DIFF
--- a/clients.go
+++ b/clients.go
@@ -89,10 +89,24 @@ func (cl *Clients) Delete(id string) {
 }
 
 // GetByListener returns clients matching a listener id.
+//
+// MAESTROHUB PATCH (deadlock): the capacity hint read cl.Len(), which takes
+// RLock a second time while this function already holds it. sync.RWMutex
+// documents that as prohibited — "if a goroutine holds a RWMutex for reading
+// and another goroutine might call Lock, no goroutine should expect to be
+// able to acquire a read lock until the initial read lock is released. In
+// particular, this prohibits recursive read locking."
+//
+// A client connecting while a listener closes is exactly that interleaving:
+// attachClient -> Clients.Delete -> Lock() queues a writer, RWMutex stops
+// admitting new readers, and this nested RLock blocks forever behind the
+// writer that is itself waiting on the RLock we still hold.
+//
+// The map is already guarded by the RLock held here, so read len directly.
 func (cl *Clients) GetByListener(id string) []*Client {
 	cl.RLock()
 	defer cl.RUnlock()
-	clients := make([]*Client, 0, cl.Len())
+	clients := make([]*Client, 0, len(cl.internal))
 	for _, client := range cl.internal {
 		if client.Net.Listener == id && !client.Closed() {
 			clients = append(clients, client)

--- a/clients_getbylistener_deadlock_test.go
+++ b/clients_getbylistener_deadlock_test.go
@@ -1,0 +1,66 @@
+package mqtt
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestClientsGetByListenerDoesNotRecurseRLock pins the MaestroHub deadlock
+// patch in GetByListener.
+//
+// Before the patch its capacity hint called cl.Len(), taking RLock a second
+// time while already holding it. sync.RWMutex forbids recursive read locking
+// precisely because a Lock() queued in between blocks the nested RLock, while
+// the writer waits on the read lock the caller still holds — a permanent
+// deadlock, not a slow path.
+//
+// The interleaving is reachable in production: a client connecting
+// (attachClient -> Clients.Delete -> Lock) as a listener closes
+// (closeListenerClients -> GetByListener). It hung two MaestroHub CI packages
+// for the full 30-minute test timeout.
+//
+// The test drives readers and writers concurrently and requires completion
+// inside a deadline. Without the patch it does not fail an assertion — it
+// hangs, which is why the deadline is the assertion.
+func TestClientsGetByListenerDoesNotRecurseRLock(t *testing.T) {
+	cl := NewClients()
+	for i := 0; i < 64; i++ {
+		id := string(rune('a'+i%26)) + string(rune('0'+i/26))
+		cl.Add(&Client{ID: id, Net: ClientConnection{Listener: "tcp1"}})
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		var wg sync.WaitGroup
+		for i := 0; i < 8; i++ {
+			wg.Add(1)
+			go func() { // readers: the nested-RLock path
+				defer wg.Done()
+				for n := 0; n < 2000; n++ {
+					_ = cl.GetByListener("tcp1")
+				}
+			}()
+		}
+		for i := 0; i < 8; i++ {
+			wg.Add(1)
+			go func(i int) { // writers: queue Lock() between the two RLocks
+				defer wg.Done()
+				id := string(rune('a' + i))
+				for n := 0; n < 2000; n++ {
+					cl.Add(&Client{ID: id, Net: ClientConnection{Listener: "tcp1"}})
+					cl.Delete(id)
+				}
+			}(i)
+		}
+		wg.Wait()
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(20 * time.Second):
+		t.Fatal("GetByListener deadlocked against a concurrent Delete — the capacity hint is " +
+			"taking RLock recursively while a writer is queued (MaestroHub patch reverted?)")
+	}
+}


### PR DESCRIPTION
`Clients.GetByListener` holds `cl.RLock()` and then calls `cl.Len()`, which takes `cl.RLock()` again:

```go
func (cl *Clients) GetByListener(id string) []*Client {
    cl.RLock()
    defer cl.RUnlock()
    clients := make([]*Client, 0, cl.Len())   // <- second RLock on the same mutex
```

Go's `sync.RWMutex` documentation prohibits exactly this: *"If a goroutine holds a RWMutex for reading and another goroutine might call Lock, no goroutine should expect to be able to acquire a read lock until the initial read lock is released."* If a writer (`cl.Add` from a new connection, `cl.Delete` from a disconnect) blocks between the two acquisitions, the second `RLock` queues behind the writer, the writer waits on the first `RLock`, and the broker deadlocks permanently — every subsequent `Clients` operation then blocks behind the stuck writer.

The trigger is ordinary traffic: a client connecting or disconnecting while another client's listener is being closed. We hit it in production use of the embedded broker (it also hung two of our CI packages for a 30-minute timeout each before we traced it).

**Fix:** size the slice from `len(cl.internal)` directly, under the single `RLock` already held. Behaviourally identical, one lock acquisition.

Includes a regression test that provokes the writer-between-readers interleaving; it fails by timeout on the old code and passes here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZT5wPg6joJZNMRGNUbiyu